### PR TITLE
Docker Support with GPU

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN git clone https://github.com/rakuri255/UltraSinger.git
 WORKDIR /app/UltraSinger
 RUN apt-get install ffmpeg curl -y
 RUN pip install --no-cache-dir -r requirements.txt
-RUN pip install --upgrade pip
 RUN pip install --no-cache-dir  torch==2.3.0 torchvision==0.18.0 torchaudio==2.3.0 --index-url https://download.pytorch.org/whl/cu121
 RUN pip install --no-cache-dir  tensorflow[and-cuda]==2.16.1
 ENV UID=0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,14 @@
 FROM nvidia/cuda:12.5.0-runtime-ubuntu22.04
 
 WORKDIR /app
-RUN apt-get update
-RUN apt-get install git python3-pip -y
+RUN apt-get update && apt-get install git python3-pip -y && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN git clone https://github.com/rakuri255/UltraSinger.git
 WORKDIR /app/UltraSinger
-RUN apt-get install ffmpeg curl -y
+RUN apt-get update && apt-get install ffmpeg curl -y && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir -r requirements.txt
-RUN pip install --no-cache-dir  torch==2.3.0 torchvision==0.18.0 torchaudio==2.3.0 --index-url https://download.pytorch.org/whl/cu121
+RUN pip install --no-cache-dir  torch==2.3.0 torchvision==0.18.0 torchaudio==2.3.0 --index-url https://download.pytorch.org/whl/cu121 
 RUN pip install --no-cache-dir  tensorflow[and-cuda]==2.16.1
-RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 ENV UID=0
 ENV GID=0
 ENV UMASK=022

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM nvidia/cuda:12.5.0-runtime-ubuntu22.04
 
 WORKDIR /app
-RUN apt update
+RUN apt-get update
 RUN apt-get install git python3-pip -y
 
 RUN git clone https://github.com/rakuri255/UltraSinger.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-FROM nogil/python-cuda
+FROM nvidia/cuda:12.5.0-runtime-ubuntu22.04
 
-
-FROM python:3.10.1-buster
 WORKDIR /app
 RUN apt update
-RUN apt install software-properties-common -y
-RUN apt install git -y
+RUN apt install git python3-pip -y
 RUN pip3 install torch==2.0.1+cu117 torchvision==0.15.2+cu117 torchaudio==2.0.2+cu117 --index-url https://download.pytorch.org/whl/cu117
 
 
@@ -16,7 +13,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 RUN git clone https://github.com/rakuri255/UltraSinger.git
 WORKDIR /app/UltraSinger
 RUN cp -Rv * ..
-RUN apt install ffmpeg -y
+RUN apt install ffmpeg curl -y
 RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /app/yt-dlp
 RUN chmod a+rx /app/yt-dlp 
 ENV UID=0

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,21 +2,19 @@ FROM nvidia/cuda:12.5.0-runtime-ubuntu22.04
 
 WORKDIR /app
 RUN apt update
-RUN apt install git python3-pip -y
+RUN apt-get install git python3-pip -y
 
 RUN git clone https://github.com/rakuri255/UltraSinger.git
 WORKDIR /app/UltraSinger
-RUN cp -Rv * ..
-WORKDIR /app
-RUN apt install ffmpeg curl -y
+RUN apt-get install ffmpeg curl -y
 RUN pip install --no-cache-dir -r requirements.txt
 RUN pip install --upgrade pip
-RUN pip install torch==2.3.0 torchvision==0.18.0 torchaudio==2.3.0 --index-url https://download.pytorch.org/whl/cu121
-RUN pip3 install tensorflow[and-cuda]==2.16.1
+RUN pip install --no-cache-dir  torch==2.3.0 torchvision==0.18.0 torchaudio==2.3.0 --index-url https://download.pytorch.org/whl/cu121
+RUN pip install --no-cache-dir  tensorflow[and-cuda]==2.16.1
 ENV UID=0
 ENV GID=0
 ENV UMASK=022
 
 EXPOSE 8088 
-WORKDIR /app/src
+WORKDIR /app/UltraSinger/src
 CMD ["bash" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get install ffmpeg curl -y
 RUN pip install --no-cache-dir -r requirements.txt
 RUN pip install --no-cache-dir  torch==2.3.0 torchvision==0.18.0 torchaudio==2.3.0 --index-url https://download.pytorch.org/whl/cu121
 RUN pip install --no-cache-dir  tensorflow[and-cuda]==2.16.1
+RUN apt-get clean 
 ENV UID=0
 ENV GID=0
 ENV UMASK=022

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get install ffmpeg curl -y
 RUN pip install --no-cache-dir -r requirements.txt
 RUN pip install --no-cache-dir  torch==2.3.0 torchvision==0.18.0 torchaudio==2.3.0 --index-url https://download.pytorch.org/whl/cu121
 RUN pip install --no-cache-dir  tensorflow[and-cuda]==2.16.1
-RUN apt-get clean 
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 ENV UID=0
 ENV GID=0
 ENV UMASK=022

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM nogil/python-cuda
+
+
+FROM python:3.10.1-buster
+WORKDIR /app
+RUN apt update
+RUN apt install software-properties-common -y
+RUN apt install git -y
+RUN pip3 install torch==2.0.1+cu117 torchvision==0.15.2+cu117 torchaudio==2.0.2+cu117 --index-url https://download.pytorch.org/whl/cu117
+
+
+WORKDIR /app
+
+COPY requirements.txt /app
+RUN pip install --no-cache-dir -r requirements.txt
+RUN git clone https://github.com/rakuri255/UltraSinger.git
+WORKDIR /app/UltraSinger
+RUN cp -Rv * ..
+RUN apt install ffmpeg -y
+RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /app/yt-dlp
+RUN chmod a+rx /app/yt-dlp 
+ENV UID=0
+ENV GID=0
+ENV UMASK=022
+
+EXPOSE 8088 
+WORKDIR /app/src
+CMD ["bash" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,19 +3,16 @@ FROM nvidia/cuda:12.5.0-runtime-ubuntu22.04
 WORKDIR /app
 RUN apt update
 RUN apt install git python3-pip -y
-RUN pip3 install torch==2.0.1+cu117 torchvision==0.15.2+cu117 torchaudio==2.0.2+cu117 --index-url https://download.pytorch.org/whl/cu117
 
-
-WORKDIR /app
-
-COPY requirements.txt /app
-RUN pip install --no-cache-dir -r requirements.txt
 RUN git clone https://github.com/rakuri255/UltraSinger.git
 WORKDIR /app/UltraSinger
 RUN cp -Rv * ..
+WORKDIR /app
 RUN apt install ffmpeg curl -y
-RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /app/yt-dlp
-RUN chmod a+rx /app/yt-dlp 
+RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --upgrade pip
+RUN pip install torch==2.3.0 torchvision==0.18.0 torchaudio==2.3.0 --index-url https://download.pytorch.org/whl/cu121
+RUN pip3 install tensorflow[and-cuda]==2.16.1
 ENV UID=0
 ENV GID=0
 ENV UMASK=022

--- a/README.md
+++ b/README.md
@@ -275,3 +275,26 @@ If something crashes because of low VRAM then use a smaller model.
 Whisper needs more than 8GB VRAM in the `large` model!
 
 You can also force cpu usage with the extra option `--force_cpu`.
+
+#### Docker
+to run the docker run `git clone https://github.com/rakuri255/UltraSinger.git`
+enter the UltraSinger folder.
+run this command to build the docker
+`docker build -t ultrasinger .` make sure to include the "." at the end
+let this run till complete.
+then run this command
+`docker run --gpus all -it --name UltraSinger -v  $(pwd)/src/output:/app/src/output ultrasinger`
+
+this will create and drop you into the docker.
+now run this command.
+`python3 UltraSinger.py -i file`
+or
+`python3 UltraSinger.py -i youtube_url`
+to use mp3's in the folder you git cloned you must place all songs you like in UltraSinger/src/output.
+this will be the place for youtube links aswell.
+
+to quit the docker just type exit.
+
+to reenter docker run this command
+`docker start UltraSinger && Docker exec -it UltraSinger /bin/bash`
+


### PR DESCRIPTION
i have created a dockerfile that does build a image that will work with a GPU pass thought
 to run this docker you need to run this command
`docker build -t ultrasinger .`

then after the build run.

`docker run --gpus all -it --name UltraSinger ultrasinger`

right now this drops you into the docker commandline.
all you have to do is run `python3 UltraSinger.py -i file`.

right now i edited the dockerfile to just copy a mp3 for testing and all works fine for me.
rightnow to use this you must run this from commandline. but its all self contained.
to get this in and out run this command instead.
`docker run --gpus all -it --name UltraSinger -v  $(pwd)/mp3:/mp3 ultrasinger` 
this will let you get files in and out of the docker.

the next step would be more testing and then making a webui to pass eveything though.

im sure there more needed then what i came up with, this is my first docker ive build.

thoughts?



