### PR TITLE
keep_cache parameter did not work

### DIFF
--- a/src/UltraSinger.py
+++ b/src/UltraSinger.py
@@ -683,7 +683,7 @@ def arg_options():
         "force_whisper_cpu=",
         "force_crepe_cpu=",
         "format_version=",
-        "keep_cache",
+        "keep_cache=",
         "musescore_path="
     ]
     return long, short


### PR DESCRIPTION
keep_cache is currently setup as _arg_, but listed in arg_options as a _noarg_ parameter.

I have other QOL improvements on my fork that turn all True/False options into noarg parameters. 