### PR TITLE
"/" in whisper align model string get interpreted as path

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -70,7 +70,7 @@ contourpy==1.2.1
     # via matplotlib
 crepe==0.0.15
     # via -r requirements.in
-ctranslate2==4.3.1
+ctranslate2==4.4.0
     # via faster-whisper
 cycler==0.12.1
     # via matplotlib

--- a/src/UltraSinger.py
+++ b/src/UltraSinger.py
@@ -466,8 +466,10 @@ def CreateProcessAudio(process_data) -> str:
 def transcribe_audio(cache_folder_path: str, processing_audio_path: str) -> TranscriptionResult:
     """Transcribe audio with AI"""
     transcription_result = None
+    whisper_align_model_string = None
     if settings.transcriber == "whisper":
-        transcription_config = f"{settings.transcriber}_{settings.whisper_model.value}_{settings.pytorch_device}_{settings.whisper_align_model}_{settings.whisper_align_model}_{settings.whisper_batch_size}_{settings.whisper_compute_type}_{settings.language}"
+        if not settings.whisper_align_model is None: whisper_align_model_string = settings.whisper_align_model.replace("/", "_")
+        transcription_config = f"{settings.transcriber}_{settings.whisper_model.value}_{settings.pytorch_device}_{whisper_align_model_string}_{settings.whisper_batch_size}_{settings.whisper_compute_type}_{settings.language}"
         transcription_path = os.path.join(cache_folder_path, f"{transcription_config}.json")
         cached_transcription_available = check_file_exists(transcription_path)
         if settings.skip_cache_transcription or not cached_transcription_available:


### PR DESCRIPTION
Not sure if this is the best solution, but what is happening in Issue #181 is that when a whisper model is added to the command line 471,         
transcription_config = f"{settings.transcriber}_{settings.whisper_model.value}_{settings.pytorch_device}_**_### {settings.whisper_align_model}_{settings.whisper_align_model}_**_{settings.whisper_batch_size}_{settings.whisper_compute_type}_{settings.language}"

will interpret the string literally. This means that pretty much any model from Hugginspace will confuse the cache path (i.e. KBLab/wav2vec2-large-voxrex-swedish would think that it is cache/KbLab/...)

Furthermore, not sure if intentional, the align model is twice in the  variable.

A quick fix is to check if the option was set and convert "/" to underscores.

That is what my solution does.

Test on: https://www.youtube.com/watch?v=17HIRea5C6Y 
with --whisper_align_model "KBLab/wav2vec2-large-voxrex-swedish"

Hope this helps :)