### PR TITLE
MonkeyPatch FasterWhisperPipeline to detect low confidence

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -31,3 +31,4 @@ unidecode
 dataclasses
 dataclasses_json
 num2words
+inputimeout

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,7 +71,9 @@ contourpy==1.2.1
 crepe==0.0.15
     # via -r requirements.in
 ctranslate2==4.4.0
-    # via faster-whisper
+    # via
+    #   faster-whisper
+    #   whisperx
 cycler==0.12.1
     # via matplotlib
 dataclasses==0.6
@@ -166,6 +168,8 @@ imageio==2.34.2
     # via crepe
 iniconfig==2.0.0
     # via pytest
+inputimeout==1.0.4
+    # via -r requirements.in
 isort==5.13.2
     # via
     #   -r requirements.in

--- a/src/Settings.py
+++ b/src/Settings.py
@@ -11,7 +11,7 @@ from modules.Ultrastar.ultrastar_txt import FormatVersion
 @dataclass
 class Settings:
     APP_VERSION = "0.0.12"
-
+    CONFIDENCE_THRESHOLD = 0.6
     create_midi = True
     create_plot = False
     create_audio_chunks = False

--- a/src/Settings.py
+++ b/src/Settings.py
@@ -10,8 +10,9 @@ from modules.Ultrastar.ultrastar_txt import FormatVersion
 @dataclass_json
 @dataclass
 class Settings:
-    APP_VERSION = "0.0.12"
+    APP_VERSION = "0.0.13-dev1"
     CONFIDENCE_THRESHOLD = 0.6
+    CONFIDENCE_PROMPT_TIMEOUT = 4
     create_midi = True
     create_plot = False
     create_audio_chunks = False


### PR DESCRIPTION
MonkeyPatch FasterWhisperPipeline to detect low confidence:

Added lines in whisperx.asr.FasterWhisperPipeline,detect_language

At the beginning to maintain consistent colors and output and to get threshold from Settings:
    #Added imports
    from modules.console_colors import ULTRASINGER_HEAD, blue_highlighted, red_highlighted
    from Settings import Settings
    #End Import addition

and at the end to handle the low confidence:
    #Added handling for low detection probability (test with https://www.youtube.com/watch?v=tcV7VN3l3bY)
    if language_probability < Settings.CONFIDENCE_THRESHOLD:
        print(f"{ULTRASINGER_HEAD} {red_highlighted('Warning:')} Language detection probability for detected language {language} is below {Settings.CONFIDENCE_THRESHOLD}, results may be inaccurate.")
        language_response = input(f"{ULTRASINGER_HEAD} Do you want to continue with {language} (default) or override with another language (y)? (y/n): ").strip().lower() == 'y'
        if language_response:
            language = input(f"{ULTRASINGER_HEAD} Please enter the language code for the language you want to use (e.g. 'en', 'de', 'es', etc.): ").strip().lower()
    #End addition