### PR TITLE
Installer Fix

### DIFF
--- a/install/CPU/windows_cpu.bat
+++ b/install/CPU/windows_cpu.bat
@@ -1,7 +1,9 @@
 @echo off
+setlocal
 cd ..
 cd ..
 py -3.10 -m venv .venv
 SET VenvPythonPath=%CD%\.venv\Scripts\python.exe
 call %VenvPythonPath% -m pip install -r requirements.txt
 call %VenvPythonPath% -m pip install torch==2.0.1 torchvision==0.15.2 torchaudio==2.0.2
+endlocal

--- a/install/CPU/windows_cpu.bat
+++ b/install/CPU/windows_cpu.bat
@@ -2,6 +2,6 @@
 cd ..
 cd ..
 py -3.10 -m venv .venv
-call .venv\Scripts\activate
-pip install -r requirements.txt
-pip install torch==2.0.1 torchvision==0.15.2 torchaudio==2.0.2
+SET VenvPythonPath=%CD%\.venv\Scripts\python.exe
+call %VenvPythonPath% -m pip install -r requirements.txt
+call %VenvPythonPath% -m pip install torch==2.0.1 torchvision==0.15.2 torchaudio==2.0.2

--- a/install/CUDA/windows_cuda_gpu.bat
+++ b/install/CUDA/windows_cuda_gpu.bat
@@ -2,6 +2,6 @@
 cd ..
 cd ..
 py -3.10 -m venv .venv
-call .venv\Scripts\activate
-pip install -r requirements.txt
-pip install torch==2.0.1+cu117 torchvision==0.15.2+cu117 torchaudio==2.0.2+cu117 --index-url https://download.pytorch.org/whl/cu117
+SET VenvPythonPath=%CD%\.venv\Scripts\python.exe
+call %VenvPythonPath% -m pip install -r requirements.txt
+call %VenvPythonPath% -m pip install torch==2.0.1+cu117 torchvision==0.15.2+cu117 torchaudio==2.0.2+cu117 --index-url https://download.pytorch.org/whl/cu117

--- a/install/CUDA/windows_cuda_gpu.bat
+++ b/install/CUDA/windows_cuda_gpu.bat
@@ -1,7 +1,9 @@
 @echo off
+setlocal
 cd ..
 cd ..
 py -3.10 -m venv .venv
 SET VenvPythonPath=%CD%\.venv\Scripts\python.exe
 call %VenvPythonPath% -m pip install -r requirements.txt
 call %VenvPythonPath% -m pip install torch==2.0.1+cu117 torchvision==0.15.2+cu117 torchaudio==2.0.2+cu117 --index-url https://download.pytorch.org/whl/cu117
+endlocal


### PR DESCRIPTION
It's actually quite easy. 

I tried a fancy shell detection, and eventually determined that it is not practical due to ExecutionPolicies, etc. 

In the end, we don't even have to enter the venv, we just need to use the pyton.exe in the venv to run the install commands.

Addresses Issue #205 