### PR TITLE
Fix container image publish

### DIFF
--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -12,7 +12,11 @@ jobs:
   push-ghcr:
     name: Build and push image
     runs-on: ubuntu-22.04
-
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This is a followup to https://github.com/rakuri255/UltraSinger/pull/226

The necessary permissions are now added to the job according to https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images#publishing-images-to-github-packages