### PR TITLE
Remove dead U+FFFD heuristic from strict decode path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 venv
 .venv
 
+# local uv config (CPU/CUDA PyTorch index override)
+uv.toml
+
 # python
 **__pycache__
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ This will help me a lot to keep this project alive and improve it.
       - [✍️ Hyphenation](#️-hyphenation)
     - [👂 Pitcher](#-pitcher)
     - [👄 Separation](#-separation)
+    - [🥁 BPM Override](#-bpm-override)
     - [Sheet Music](#sheet-music)
     - [Format Version](#format-version)
     - [🏆 Ultrastar Score Calculation](#-ultrastar-score-calculation)
@@ -120,6 +121,7 @@ _Not all options working now!_
     --keep_numbers          Numbers will be transcribed as numerics instead of as words
 
     [extra]
+    --bpm                   Override auto-detected BPM with a manual value (e.g., --bpm 120)
     --disable_hyphenation   Disable word hyphenation. Hyphenation is enabled by default.
     --disable_separation    Disable track separation. Track separation is enabled by default.
     --disable_karaoke       Disable creation of karaoke style txt file. Karaoke is enabled by default.
@@ -234,6 +236,16 @@ By default, UltraSinger quantizes all detected notes to the detected musical key
 
 If you want to keep the raw pitch detection without quantization, set `quantize_to_key = False`.
 For most songs  quantization should produces better results.
+
+### 🥁 BPM Override
+
+UltraSinger automatically detects the BPM of the song. If the auto-detection gives an incorrect result, you can manually override it with the `--bpm` option. The value must be a positive number.
+
+```commandline
+-i XYZ --bpm 120
+```
+
+This skips the automatic BPM detection and uses the provided value instead. Decimal values are also supported. You can find the correct BPM for most songs on sites like [songbpm.com](https://songbpm.com/) or in the song's metadata.
 
 ### Sheet Music
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ _Not all options working now!_
     --ffmpeg                Path to ffmpeg and ffprobe executable
 
     [yt-dlp]
-    --cookiefile            File name where cookies should be read from
+    --cookiefile            Path to a Netscape-format cookies.txt file for YouTube authentication
+    --cookies_from_browser  Browser to read cookies from (e.g. chrome, firefox, edge, opera, brave)
 
     [device]
     --force_cpu             Force all steps to be processed on CPU.
@@ -164,10 +165,31 @@ default (Full Automatic Mode) - Creates all, depending on command line options
 -i https://www.youtube.com/watch?v=YwNs1Z0qRY0
 ```
 
-Note that if you run into a yt-dlp error such as `Sign in to confirm you’re not a bot. This helps protect our community` ([yt-dlp issue](https://github.com/yt-dlp/yt-dlp/issues/10128)) you can follow these steps:
+Note that if you run into a yt-dlp error such as `Sign in to confirm you’re not a bot. This helps protect our community` ([yt-dlp issue](https://github.com/yt-dlp/yt-dlp/issues/10128)) you can authenticate using one of two methods:
 
-* generate a cookies.txt file with [yt-dlp](https://github.com/yt-dlp/yt-dlp/wiki/Installation) `yt-dlp --cookies cookies.txt --cookies-from-browser firefox`
-* then pass the cookies.txt to UltraSinger `--cookiefile cookies.txt`
+**Option 1: Browser cookies (recommended)**
+
+Let UltraSinger read cookies directly from your browser. This is the most reliable method because it always uses fresh session cookies and you don’t have to manually export a file:
+
+```commandline
+-i https://www.youtube.com/watch?v=YwNs1Z0qRY0 --cookies_from_browser firefox
+```
+
+Supported browsers: `chrome`, `firefox`, `edge`, `opera`, `brave`, `chromium`, `vivaldi`, `safari`.
+
+> **Note:** The browser must be closed before UltraSinger can read its cookies (some browsers lock their cookie database while running).
+
+**Option 2: Cookie file**
+
+Export a `cookies.txt` file using yt-dlp or a browser extension, then pass it to UltraSinger:
+
+```commandline
+-i https://www.youtube.com/watch?v=YwNs1Z0qRY0 --cookiefile cookies.txt
+```
+
+> **Note:** Cookie files can go stale quickly. If downloads start failing again, re-export the file or switch to `--cookies_from_browser`.
+
+If both `--cookies_from_browser` and `--cookiefile` are provided, the browser cookies take precedence.
 
 #### UltraStar (re-pitch)
 

--- a/README.md
+++ b/README.md
@@ -133,8 +133,7 @@ _Not all options working now!_
     --ffmpeg                Path to ffmpeg and ffprobe executable
 
     [yt-dlp]
-    --cookiefile            Path to a Netscape-format cookies.txt file for YouTube authentication
-    --cookies_from_browser  Browser to read cookies from (e.g. chrome, firefox, edge, opera, brave)
+    --cookiefile            File name where cookies should be read from
 
     [device]
     --force_cpu             Force all steps to be processed on CPU.
@@ -165,31 +164,10 @@ default (Full Automatic Mode) - Creates all, depending on command line options
 -i https://www.youtube.com/watch?v=YwNs1Z0qRY0
 ```
 
-Note that if you run into a yt-dlp error such as `Sign in to confirm you’re not a bot. This helps protect our community` ([yt-dlp issue](https://github.com/yt-dlp/yt-dlp/issues/10128)) you can authenticate using one of two methods:
+Note that if you run into a yt-dlp error such as `Sign in to confirm you’re not a bot. This helps protect our community` ([yt-dlp issue](https://github.com/yt-dlp/yt-dlp/issues/10128)) you can follow these steps:
 
-**Option 1: Browser cookies (recommended)**
-
-Let UltraSinger read cookies directly from your browser. This is the most reliable method because it always uses fresh session cookies and you don’t have to manually export a file:
-
-```commandline
--i https://www.youtube.com/watch?v=YwNs1Z0qRY0 --cookies_from_browser firefox
-```
-
-Supported browsers: `chrome`, `firefox`, `edge`, `opera`, `brave`, `chromium`, `vivaldi`, `safari`.
-
-> **Note:** The browser must be closed before UltraSinger can read its cookies (some browsers lock their cookie database while running).
-
-**Option 2: Cookie file**
-
-Export a `cookies.txt` file using yt-dlp or a browser extension, then pass it to UltraSinger:
-
-```commandline
--i https://www.youtube.com/watch?v=YwNs1Z0qRY0 --cookiefile cookies.txt
-```
-
-> **Note:** Cookie files can go stale quickly. If downloads start failing again, re-export the file or switch to `--cookies_from_browser`.
-
-If both `--cookies_from_browser` and `--cookiefile` are provided, the browser cookies take precedence.
+* generate a cookies.txt file with [yt-dlp](https://github.com/yt-dlp/yt-dlp/wiki/Installation) `yt-dlp --cookies cookies.txt --cookies-from-browser firefox`
+* then pass the cookies.txt to UltraSinger `--cookiefile cookies.txt`
 
 #### UltraStar (re-pitch)
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This will help me a lot to keep this project alive and improve it.
     - [👂 Pitcher](#-pitcher)
     - [👄 Separation](#-separation)
     - [🥁 BPM Override](#-bpm-override)
+    - [🎵 Octave Shift](#-octave-shift)
     - [Sheet Music](#sheet-music)
     - [Format Version](#format-version)
     - [🏆 Ultrastar Score Calculation](#-ultrastar-score-calculation)
@@ -122,6 +123,7 @@ _Not all options working now!_
 
     [extra]
     --bpm                   Override auto-detected BPM with a manual value (e.g., --bpm 120)
+    --octave                Shift all notes by N octaves after pitch detection (e.g., --octave 1 for one octave up)
     --disable_hyphenation   Disable word hyphenation. Hyphenation is enabled by default.
     --disable_separation    Disable track separation. Track separation is enabled by default.
     --disable_karaoke       Disable creation of karaoke style txt file. Karaoke is enabled by default.
@@ -246,6 +248,16 @@ UltraSinger automatically detects the BPM of the song. If the auto-detection giv
 ```
 
 This skips the automatic BPM detection and uses the provided value instead. Decimal values are also supported. You can find the correct BPM for most songs on sites like [songbpm.com](https://songbpm.com/) or in the song's metadata.
+
+### 🎵 Octave Shift
+
+UltraSinger includes automatic octave correction, but in rare cases the pitch detector may consistently detect the wrong octave for an entire song. If all notes sound correct in relative pitch but are shifted by one or more octaves, use the `--octave` option to manually correct them.
+
+```commandline
+-i XYZ --octave 1
+```
+
+The value is an integer: positive values shift up, negative values shift down. For example, `--octave 1` shifts all notes up by one octave, `--octave -1` shifts down. The shift is applied after automatic octave correction, so it acts as a final override.
 
 ### Sheet Music
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ _Not all options working now!_
     --create_audio_chunks   Enable creation of audio chunks. Audio chunks are disabled by default.
     --keep_cache            Keep cache folder after creation. Cache folder is removed by default.
     --plot                  Enable creation of plots. Plots are disabled by default.
-    --quantize_to_key       Quantize notes to detected musical key. Removes pitch slides and out-of-key notes. >> ((default) is enabled)
+    --disable_quantization  Disable key quantization. Key quantization is enabled by default and removes pitch slides and out-of-key notes.
     --format_version        0.3.0|1.0.0|1.1.0|1.2.0 >> ((default) is 1.2.0)
     --musescore_path        path to MuseScore executable
     --keep_numbers          Transcribe numbers as digits and not words
@@ -236,8 +236,13 @@ By default, UltraSinger quantizes all detected notes to the detected musical key
 * Remove pitch slides and vocal transitions between notes
 * Correct out-of-key notes from pitch detection errors
 
-If you want to keep the raw pitch detection without quantization, set `quantize_to_key = False`.
-For most songs  quantization should produces better results.
+If you want to keep the raw pitch detection without quantization:
+
+```commandline
+-i XYZ --disable_quantization
+```
+
+For most songs, quantization produces better results.
 
 ### 🥁 BPM Override
 

--- a/install/CPU/linux_cpu.sh
+++ b/install/CPU/linux_cpu.sh
@@ -25,7 +25,20 @@ fi
 echo "uv version:"
 uv --version
 
-echo "Syncing dependencies with uv..."
+# Remove old virtual environment to ensure clean state (e.g., switching between CPU/CUDA)
+if [ -d ".venv" ]; then
+    echo "Removing old virtual environment..."
+    rm -rf .venv
+fi
+
+# Ensure PyTorch index is set to CPU in pyproject.toml
+# (restores default if previously changed by CUDA install script)
+sed 's|whl/cu[0-9]*|whl/cpu|' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
+
+# Regenerate lockfile with CPU PyTorch index and sync
+echo "Resolving dependencies..."
+uv lock
+echo "Syncing dependencies..."
 uv sync --extra linux
 
 echo "Installation completed successfully!"

--- a/install/CPU/linux_cpu.sh
+++ b/install/CPU/linux_cpu.sh
@@ -31,9 +31,16 @@ if [ -d ".venv" ]; then
     rm -rf .venv
 fi
 
+# Clear skip-worktree flags if previously set by CUDA install script
+# (allows git to manage these files normally again since CPU is the default)
+if command -v git &> /dev/null && git rev-parse --is-inside-work-tree &> /dev/null; then
+    git update-index --no-skip-worktree pyproject.toml 2>/dev/null || true
+    git update-index --no-skip-worktree uv.lock 2>/dev/null || true
+fi
+
 # Ensure PyTorch index is set to CPU in pyproject.toml
 # (restores default if previously changed by CUDA install script)
-sed 's|whl/cu[0-9]*|whl/cpu|' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
+sed -i 's|whl/cu[0-9]*|whl/cpu|' pyproject.toml
 
 # Regenerate lockfile with CPU PyTorch index and sync
 echo "Resolving dependencies..."
@@ -45,4 +52,4 @@ echo "Installation completed successfully!"
 echo "To run UltraSinger:"
 echo "  source .venv/bin/activate"
 echo "  cd src"
-echo "  py UltraSinger.py"
+echo "  python UltraSinger.py"

--- a/install/CPU/macos_cpu.sh
+++ b/install/CPU/macos_cpu.sh
@@ -25,7 +25,20 @@ fi
 echo "uv version:"
 uv --version
 
-echo "Syncing dependencies with uv..."
+# Remove old virtual environment to ensure clean state (e.g., switching between CPU/CUDA)
+if [ -d ".venv" ]; then
+    echo "Removing old virtual environment..."
+    rm -rf .venv
+fi
+
+# Ensure PyTorch index is set to CPU in pyproject.toml
+# (restores default if previously changed by CUDA install script)
+sed 's|whl/cu[0-9]*|whl/cpu|' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
+
+# Regenerate lockfile with CPU PyTorch index and sync
+echo "Resolving dependencies..."
+uv lock
+echo "Syncing dependencies..."
 uv sync --extra macos
 
 echo "Installation completed successfully!"

--- a/install/CPU/macos_cpu.sh
+++ b/install/CPU/macos_cpu.sh
@@ -31,9 +31,16 @@ if [ -d ".venv" ]; then
     rm -rf .venv
 fi
 
+# Clear skip-worktree flags if previously set by CUDA install script
+# (allows git to manage these files normally again since CPU is the default)
+if command -v git &> /dev/null && git rev-parse --is-inside-work-tree &> /dev/null; then
+    git update-index --no-skip-worktree pyproject.toml 2>/dev/null || true
+    git update-index --no-skip-worktree uv.lock 2>/dev/null || true
+fi
+
 # Ensure PyTorch index is set to CPU in pyproject.toml
 # (restores default if previously changed by CUDA install script)
-sed 's|whl/cu[0-9]*|whl/cpu|' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
+sed -i '' 's|whl/cu[0-9]*|whl/cpu|' pyproject.toml
 
 # Regenerate lockfile with CPU PyTorch index and sync
 echo "Resolving dependencies..."
@@ -45,4 +52,4 @@ echo "Installation completed successfully!"
 echo "To run UltraSinger:"
 echo "  source .venv/bin/activate"
 echo "  cd src"
-echo "  py UltraSinger.py"
+echo "  python UltraSinger.py"

--- a/install/CPU/windows_cpu.bat
+++ b/install/CPU/windows_cpu.bat
@@ -74,9 +74,19 @@ if !errorlevel! neq 0 (
 echo uv is ready
 uv --version
 
+:: Clear skip-worktree flags if previously set by CUDA install script
+:: (allows git to manage these files normally again since CPU is the default)
+where git >nul 2>&1
+if !errorlevel! equ 0 (
+    git update-index --no-skip-worktree pyproject.toml 2>nul
+    git update-index --no-skip-worktree uv.lock 2>nul
+)
+
 :: Ensure PyTorch index is set to CPU in pyproject.toml
 :: (restores default if previously changed by CUDA install script)
-powershell -NoProfile -Command "(Get-Content pyproject.toml) -replace 'whl/cu\d+', 'whl/cpu' | Set-Content pyproject.toml -Encoding UTF8"
+:: Use .NET WriteAllText to avoid UTF-8 BOM that breaks TOML parsing
+:: (PowerShell 5.x Set-Content -Encoding UTF8 adds a BOM)
+powershell -NoProfile -Command "$c = [IO.File]::ReadAllText('pyproject.toml'); $c = $c -replace 'whl/cu\d+','whl/cpu'; [IO.File]::WriteAllText('pyproject.toml', $c)"
 
 :: Regenerate lockfile with CPU PyTorch index
 echo Resolving dependencies...

--- a/install/CPU/windows_cpu.bat
+++ b/install/CPU/windows_cpu.bat
@@ -12,11 +12,11 @@ echo Current directory: %cd%
 :: Update PATH to include uv installation directory
 set "PATH=%USERPROFILE%\.local\bin;!PATH!"
 
-:: Remove old virtual environment if it exists to force recreation with correct Python version
-::if exist .venv (
-::    echo Removing old virtual environment...
-::    rmdir /s /q .venv
-::)
+:: Remove old virtual environment to ensure clean state (e.g., switching between CPU/CUDA)
+if exist .venv (
+    echo Removing old virtual environment...
+    rmdir /s /q .venv
+)
 
 :: First, find Python using to get full path
 set "PYTHON_EXE="
@@ -74,21 +74,23 @@ if !errorlevel! neq 0 (
 echo uv is ready
 uv --version
 
-echo Syncing dependencies with uv...
-uv sync --extra windows --python "!PYTHON_EXE!"
+:: Ensure PyTorch index is set to CPU in pyproject.toml
+:: (restores default if previously changed by CUDA install script)
+powershell -NoProfile -Command "(Get-Content pyproject.toml) -replace 'whl/cu\d+', 'whl/cpu' | Set-Content pyproject.toml -Encoding UTF8"
+
+:: Regenerate lockfile with CPU PyTorch index
+echo Resolving dependencies...
+uv lock
 if !errorlevel! neq 0 (
-    echo Error during uv sync
+    echo Error during uv lock
     pause
     exit /b 1
 )
 
-echo Installing PyTorch CPU version...
-:: First remove any existing torch installation to avoid RECORD file issues
-uv pip uninstall torch torchvision torchaudio -y 2>nul
-:: Install PyTorch CPU version
-uv pip install --index-url https://download.pytorch.org/whl/cpu torch torchvision torchaudio
+echo Syncing dependencies...
+uv sync --extra windows --python "!PYTHON_EXE!"
 if !errorlevel! neq 0 (
-    echo Error during PyTorch installation
+    echo Error during uv sync
     pause
     exit /b 1
 )

--- a/install/CUDA/linux_cuda_gpu.sh
+++ b/install/CUDA/linux_cuda_gpu.sh
@@ -34,13 +34,21 @@ fi
 # Set PyTorch index to CUDA in pyproject.toml
 # (uv.toml cannot override named indexes used by [tool.uv.sources])
 echo "Configuring PyTorch index for CUDA..."
-sed 's|whl/cpu|whl/cu128|' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
+sed -i 's|whl/cpu|whl/cu128|' pyproject.toml
 
 # Regenerate lockfile with CUDA PyTorch index and sync
 echo "Resolving dependencies..."
 uv lock
 echo "Syncing dependencies..."
 uv sync --extra linux
+
+# Protect local CUDA config from being reverted by git operations
+# (branch switches, pulls, etc. would otherwise reset to CPU default)
+if command -v git &> /dev/null && git rev-parse --is-inside-work-tree &> /dev/null; then
+    echo "Protecting CUDA configuration from git resets..."
+    git update-index --skip-worktree pyproject.toml
+    git update-index --skip-worktree uv.lock
+fi
 
 echo "Installation completed successfully!"
 echo "To run UltraSinger:"

--- a/install/CUDA/linux_cuda_gpu.sh
+++ b/install/CUDA/linux_cuda_gpu.sh
@@ -25,13 +25,22 @@ fi
 echo "uv version:"
 uv --version
 
-# Sync dependencies from pyproject.toml
-echo "Syncing dependencies from pyproject.toml..."
-uv sync --extra linux
+# Remove old virtual environment to ensure clean state (e.g., switching between CPU/CUDA)
+if [ -d ".venv" ]; then
+    echo "Removing old virtual environment..."
+    rm -rf .venv
+fi
 
-# Install PyTorch with CUDA support
-echo "Installing PyTorch with CUDA support..."
-uv pip install torch==2.8.0 torchvision==0.23.0 torchaudio==2.8.0 --index-url https://download.pytorch.org/whl/cu128 --force-reinstall
+# Set PyTorch index to CUDA in pyproject.toml
+# (uv.toml cannot override named indexes used by [tool.uv.sources])
+echo "Configuring PyTorch index for CUDA..."
+sed 's|whl/cpu|whl/cu128|' pyproject.toml > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
+
+# Regenerate lockfile with CUDA PyTorch index and sync
+echo "Resolving dependencies..."
+uv lock
+echo "Syncing dependencies..."
+uv sync --extra linux
 
 echo "Installation completed successfully!"
 echo "To run UltraSinger:"

--- a/install/CUDA/windows_cuda_gpu.bat
+++ b/install/CUDA/windows_cuda_gpu.bat
@@ -12,11 +12,11 @@ echo Current directory: %cd%
 :: Update PATH to include uv installation directory
 set "PATH=%USERPROFILE%\.local\bin;!PATH!"
 
-:: Remove old virtual environment if it exists to force recreation with correct Python version
-::if exist .venv (
-::    echo Removing old virtual environment...
-::    rmdir /s /q .venv
-::)
+:: Remove old virtual environment to ensure clean state (e.g., switching between CPU/CUDA)
+if exist .venv (
+    echo Removing old virtual environment...
+    rmdir /s /q .venv
+)
 
 :: First, find Python using to get full path
 set "PYTHON_EXE="
@@ -74,22 +74,24 @@ if !errorlevel! neq 0 (
 echo uv is ready
 uv --version
 
-echo Syncing dependencies with uv...
-uv sync --extra windows --python "!PYTHON_EXE!"
+:: Set PyTorch index to CUDA in pyproject.toml
+:: (uv.toml cannot override named indexes used by [tool.uv.sources])
+echo Configuring PyTorch index for CUDA...
+powershell -NoProfile -Command "(Get-Content pyproject.toml) -replace 'whl/cpu', 'whl/cu128' | Set-Content pyproject.toml -Encoding UTF8"
+
+:: Regenerate lockfile with CUDA PyTorch index
+echo Resolving dependencies...
+uv lock
 if !errorlevel! neq 0 (
-    echo Error during uv sync
+    echo Error during uv lock
     pause
     exit /b 1
 )
 
-echo Installing PyTorch with CUDA support (as recommended by WhisperX)...
-:: First remove any existing torch installation to avoid RECORD file issues
-uv pip uninstall torch torchvision torchaudio -y 2>nul
-:: Install PyTorch 2.8.0 with CUDA for WhisperX compatibility
-:: This version includes cuDNN 9.x which is compatible with the latest PyTorch
-uv pip install torch==2.8.0 torchvision==0.23.0 torchaudio==2.8.0 --index-url https://download.pytorch.org/whl/cu128 --force-reinstall
+echo Syncing dependencies...
+uv sync --extra windows --python "!PYTHON_EXE!"
 if !errorlevel! neq 0 (
-    echo Error during PyTorch installation
+    echo Error during uv sync
     pause
     exit /b 1
 )

--- a/install/CUDA/windows_cuda_gpu.bat
+++ b/install/CUDA/windows_cuda_gpu.bat
@@ -77,7 +77,9 @@ uv --version
 :: Set PyTorch index to CUDA in pyproject.toml
 :: (uv.toml cannot override named indexes used by [tool.uv.sources])
 echo Configuring PyTorch index for CUDA...
-powershell -NoProfile -Command "(Get-Content pyproject.toml) -replace 'whl/cpu', 'whl/cu128' | Set-Content pyproject.toml -Encoding UTF8"
+:: Use .NET WriteAllText to avoid UTF-8 BOM that breaks TOML parsing
+:: (PowerShell 5.x Set-Content -Encoding UTF8 adds a BOM)
+powershell -NoProfile -Command "$c = [IO.File]::ReadAllText('pyproject.toml'); $c = $c -replace 'whl/cpu','whl/cu128'; [IO.File]::WriteAllText('pyproject.toml', $c)"
 
 :: Regenerate lockfile with CUDA PyTorch index
 echo Resolving dependencies...
@@ -94,6 +96,15 @@ if !errorlevel! neq 0 (
     echo Error during uv sync
     pause
     exit /b 1
+)
+
+:: Protect local CUDA config from being reverted by git operations
+:: (branch switches, pulls, etc. would otherwise reset to CPU default)
+where git >nul 2>&1
+if !errorlevel! equ 0 (
+    echo Protecting CUDA configuration from git resets...
+    git update-index --skip-worktree pyproject.toml
+    git update-index --skip-worktree uv.lock
 )
 
 echo Installation completed successfully!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,3 +57,13 @@ profile = "black"
 pythonpath = [
   "src",
 ]
+
+[[tool.uv.index]]
+name = "pytorch"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
+
+[tool.uv.sources]
+torch = [{ index = "pytorch" }]
+torchaudio = [{ index = "pytorch" }]
+torchvision = [{ index = "pytorch" }]

--- a/pytest/modules/Audio/test_bpm.py
+++ b/pytest/modules/Audio/test_bpm.py
@@ -1,0 +1,170 @@
+"""Tests for bpm.py -- tempo-ratio correction."""
+
+import unittest
+
+from src.modules.Audio.bpm import _TEMPO_RATIOS, _pick_best_tempo
+
+
+class TestPickBestTempo(unittest.TestCase):
+    """Tests for _pick_best_tempo()."""
+
+    # -- edge cases -----------------------------------------------------------
+
+    def test_zero_returns_target(self):
+        self.assertEqual(_pick_best_tempo(0.0), 120.0)
+
+    def test_negative_returns_target(self):
+        self.assertEqual(_pick_best_tempo(-50.0), 120.0)
+
+    def test_custom_target_returned_for_zero(self):
+        self.assertEqual(_pick_best_tempo(0.0, target=100.0), 100.0)
+
+    # -- identity (already in range) ------------------------------------------
+
+    def test_in_range_returns_identity(self):
+        """120 BPM is already perfect -- no correction needed."""
+        self.assertEqual(_pick_best_tempo(120.0), 120.0)
+
+    def test_moderate_tempo_unchanged(self):
+        """100 BPM is in range and closer to 120 than any variant."""
+        self.assertEqual(_pick_best_tempo(100.0), 100.0)
+
+    def test_fast_tempo_in_range_unchanged(self):
+        """Fast tempos inside the range must not be rescaled."""
+        for bpm in [150.0, 170.0, 180.0, 195.0, 200.0]:
+            self.assertEqual(
+                _pick_best_tempo(bpm), bpm,
+                f"{bpm} BPM is in range but was rescaled",
+            )
+
+    def test_slow_tempo_in_range_unchanged(self):
+        """Slow tempos inside the range must not be rescaled."""
+        for bpm in [60.0, 65.0, 70.0, 80.0]:
+            self.assertEqual(
+                _pick_best_tempo(bpm), bpm,
+                f"{bpm} BPM is in range but was rescaled",
+            )
+
+    # -- half-tempo correction ------------------------------------------------
+
+    def test_double_detected_corrected_to_half(self):
+        """Detector reports 240 BPM (double). Half = 120, which is ideal."""
+        self.assertEqual(_pick_best_tempo(240.0), 120.0)
+
+    def test_slightly_above_range_halved(self):
+        """220 BPM is above range. Half = 110, which is in range."""
+        self.assertEqual(_pick_best_tempo(220.0), 110.0)
+
+    # -- double-tempo correction ----------------------------------------------
+
+    def test_half_detected_corrected_to_double(self):
+        """Detector reports 55 BPM (half). Double = 110, in range."""
+        self.assertEqual(_pick_best_tempo(55.0), 110.0)
+
+    # -- third-tempo correction -----------------------------------------------
+
+    def test_triple_detected_corrected_to_third(self):
+        """Detector reports 360 BPM (triple). Third = 120, ideal."""
+        self.assertEqual(_pick_best_tempo(360.0), 120.0)
+
+    def test_waltz_triple_tempo(self):
+        """Detector reports 390 BPM. Third = 130, in range and close."""
+        self.assertEqual(_pick_best_tempo(390.0), 130.0)
+
+    # -- quarter-tempo correction ---------------------------------------------
+
+    def test_quadruple_detected_corrected_to_quarter(self):
+        """Detector reports 480 BPM (quadruple). Quarter = 120, ideal."""
+        self.assertEqual(_pick_best_tempo(480.0), 120.0)
+
+    def test_high_tempo_uses_quarter(self):
+        """500 BPM. Quarter = 125, in range."""
+        self.assertEqual(_pick_best_tempo(500.0), 125.0)
+
+    # -- two-thirds correction ------------------------------------------------
+
+    def test_in_range_not_rescaled(self):
+        """180 BPM is in range -- must NOT be rescaled to 120 via 2/3 ratio.
+
+        Legitimate fast songs should keep their detected tempo; ratio
+        correction only applies to out-of-range values.
+        """
+        self.assertEqual(_pick_best_tempo(180.0), 180.0)
+
+    def test_two_thirds_correction_out_of_range(self):
+        """270 BPM is above range. 270 * 2/3 = 180, in range."""
+        self.assertEqual(_pick_best_tempo(270.0), 135.0)  # half = 135, closer to 120
+
+    # -- simpler ratios win ties ----------------------------------------------
+
+    def test_simpler_ratio_wins_tie(self):
+        """When two candidates are equally close to 120, the simpler
+        ratio (earlier in _TEMPO_RATIOS) should win.
+
+        Example: primary=120. Identity gives 120 (exact match).
+        Other ratios may also produce values, but identity wins.
+        """
+        self.assertEqual(_pick_best_tempo(120.0), 120.0)
+
+    # -- nothing in range falls back ------------------------------------------
+
+    def test_nothing_in_range_returns_primary(self):
+        """If no candidate falls in range, return the primary as-is."""
+        # 10 BPM: candidates are 10, 5, 20, 3.3, 30, 2.5, 40, 6.7, 15, 7.5
+        # None of these are in 60-200
+        self.assertEqual(_pick_best_tempo(10.0), 10.0)
+
+    # -- custom range ---------------------------------------------------------
+
+    def test_custom_range_respected(self):
+        """Custom low/high/target boundaries should be used."""
+        # 300 BPM with range 200-400 and target 300: identity wins
+        self.assertEqual(
+            _pick_best_tempo(300.0, low=200.0, high=400.0, target=300.0),
+            300.0,
+        )
+
+    def test_custom_narrow_range(self):
+        """Narrow range forces specific candidate selection."""
+        # 240 BPM with range 115-125: half = 120 is in range
+        self.assertEqual(
+            _pick_best_tempo(240.0, low=115.0, high=125.0), 120.0
+        )
+
+    # -- result is always in range when candidates exist ----------------------
+
+    def test_result_in_range(self):
+        """For typical inputs, the result should be within the default range."""
+        test_values = [75.0, 90.0, 110.0, 130.0, 150.0, 170.0, 200.0, 250.0, 300.0, 400.0]
+        for bpm in test_values:
+            result = _pick_best_tempo(bpm)
+            # Check that result is in range (if any candidate was in range)
+            candidates = [bpm * r for r in _TEMPO_RATIOS]
+            has_candidate_in_range = any(60 <= c <= 200 for c in candidates)
+            if has_candidate_in_range:
+                self.assertGreaterEqual(
+                    result, 60.0, f"Result {result} below range for input {bpm}"
+                )
+                self.assertLessEqual(
+                    result, 200.0, f"Result {result} above range for input {bpm}"
+                )
+
+    # -- backward compatibility: half/double still work -----------------------
+
+    def test_backward_compat_half(self):
+        """Original half-tempo case still works."""
+        # 240 -> half = 120 (closest to target)
+        self.assertEqual(_pick_best_tempo(240.0), 120.0)
+
+    def test_backward_compat_double(self):
+        """Original double-tempo case still works."""
+        # 55 -> double = 110 (in range, closest to target)
+        self.assertEqual(_pick_best_tempo(55.0), 110.0)
+
+    def test_backward_compat_in_range(self):
+        """Original in-range case still works."""
+        self.assertEqual(_pick_best_tempo(120.0), 120.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pytest/modules/Audio/test_bpm.py
+++ b/pytest/modules/Audio/test_bpm.py
@@ -6,32 +6,39 @@ from src.modules.Audio.bpm import _TEMPO_RATIOS, _pick_best_tempo
 
 
 class TestPickBestTempo(unittest.TestCase):
-    """Tests for _pick_best_tempo()."""
+    """Tests for _pick_best_tempo().
+
+    Default range is [50, 500] with target=None (no bias toward any
+    particular tempo).  Values inside the range pass through unchanged;
+    out-of-range values are corrected using the candidate closest to
+    the detected value.
+    """
 
     # -- edge cases -----------------------------------------------------------
 
-    def test_zero_returns_target(self):
+    def test_zero_returns_fallback(self):
         self.assertEqual(_pick_best_tempo(0.0), 120.0)
 
-    def test_negative_returns_target(self):
+    def test_negative_returns_fallback(self):
         self.assertEqual(_pick_best_tempo(-50.0), 120.0)
 
-    def test_custom_target_returned_for_zero(self):
-        self.assertEqual(_pick_best_tempo(0.0, target=100.0), 100.0)
+    def test_custom_target_does_not_affect_zero_fallback(self):
+        """Zero input always returns 120.0 regardless of target."""
+        self.assertEqual(_pick_best_tempo(0.0, target=100.0), 120.0)
 
     # -- identity (already in range) ------------------------------------------
 
     def test_in_range_returns_identity(self):
-        """120 BPM is already perfect -- no correction needed."""
+        """120 BPM is in [50, 500] -- returned unchanged."""
         self.assertEqual(_pick_best_tempo(120.0), 120.0)
 
     def test_moderate_tempo_unchanged(self):
-        """100 BPM is in range and closer to 120 than any variant."""
+        """100 BPM is in range -- returned unchanged."""
         self.assertEqual(_pick_best_tempo(100.0), 100.0)
 
     def test_fast_tempo_in_range_unchanged(self):
         """Fast tempos inside the range must not be rescaled."""
-        for bpm in [150.0, 170.0, 180.0, 195.0, 200.0]:
+        for bpm in [150.0, 170.0, 180.0, 195.0, 200.0, 300.0, 400.0, 500.0]:
             self.assertEqual(
                 _pick_best_tempo(bpm), bpm,
                 f"{bpm} BPM is in range but was rescaled",
@@ -39,80 +46,109 @@ class TestPickBestTempo(unittest.TestCase):
 
     def test_slow_tempo_in_range_unchanged(self):
         """Slow tempos inside the range must not be rescaled."""
-        for bpm in [60.0, 65.0, 70.0, 80.0]:
+        for bpm in [50.0, 55.0, 60.0, 65.0, 70.0, 80.0]:
             self.assertEqual(
                 _pick_best_tempo(bpm), bpm,
                 f"{bpm} BPM is in range but was rescaled",
             )
 
-    # -- half-tempo correction ------------------------------------------------
+    # -- values that were previously "corrected" but now pass through ---------
 
-    def test_double_detected_corrected_to_half(self):
-        """Detector reports 240 BPM (double). Half = 120, which is ideal."""
-        self.assertEqual(_pick_best_tempo(240.0), 120.0)
+    def test_240_bpm_in_range_unchanged(self):
+        """240 BPM is inside [50, 500] -- no correction needed."""
+        self.assertEqual(_pick_best_tempo(240.0), 240.0)
 
-    def test_slightly_above_range_halved(self):
-        """220 BPM is above range. Half = 110, which is in range."""
-        self.assertEqual(_pick_best_tempo(220.0), 110.0)
+    def test_220_bpm_in_range_unchanged(self):
+        """220 BPM is inside [50, 500] -- no correction needed."""
+        self.assertEqual(_pick_best_tempo(220.0), 220.0)
 
-    # -- double-tempo correction ----------------------------------------------
+    def test_360_bpm_in_range_unchanged(self):
+        """360 BPM is inside [50, 500] -- no correction needed."""
+        self.assertEqual(_pick_best_tempo(360.0), 360.0)
 
-    def test_half_detected_corrected_to_double(self):
-        """Detector reports 55 BPM (half). Double = 110, in range."""
-        self.assertEqual(_pick_best_tempo(55.0), 110.0)
+    def test_390_bpm_in_range_unchanged(self):
+        """390 BPM is inside [50, 500] -- no correction needed."""
+        self.assertEqual(_pick_best_tempo(390.0), 390.0)
 
-    # -- third-tempo correction -----------------------------------------------
+    def test_480_bpm_in_range_unchanged(self):
+        """480 BPM is inside [50, 500] -- no correction needed."""
+        self.assertEqual(_pick_best_tempo(480.0), 480.0)
 
-    def test_triple_detected_corrected_to_third(self):
-        """Detector reports 360 BPM (triple). Third = 120, ideal."""
-        self.assertEqual(_pick_best_tempo(360.0), 120.0)
+    def test_270_bpm_in_range_unchanged(self):
+        """270 BPM is inside [50, 500] -- no correction needed."""
+        self.assertEqual(_pick_best_tempo(270.0), 270.0)
 
-    def test_waltz_triple_tempo(self):
-        """Detector reports 390 BPM. Third = 130, in range and close."""
-        self.assertEqual(_pick_best_tempo(390.0), 130.0)
+    # -- core regression test: the original motivating case -------------------
 
-    # -- quarter-tempo correction ---------------------------------------------
+    def test_bpm_409_passes_through(self):
+        """409.66 BPM must pass through unchanged (UltraStar timing resolution).
 
-    def test_quadruple_detected_corrected_to_quarter(self):
-        """Detector reports 480 BPM (quadruple). Quarter = 120, ideal."""
-        self.assertEqual(_pick_best_tempo(480.0), 120.0)
-
-    def test_high_tempo_uses_quarter(self):
-        """500 BPM. Quarter = 125, in range."""
-        self.assertEqual(_pick_best_tempo(500.0), 125.0)
-
-    # -- two-thirds correction ------------------------------------------------
-
-    def test_in_range_not_rescaled(self):
-        """180 BPM is in range -- must NOT be rescaled to 120 via 2/3 ratio.
-
-        Legitimate fast songs should keep their detected tempo; ratio
-        correction only applies to out-of-range values.
+        This was the original problem: librosa detected 409.66 BPM but the
+        old range [60, 200] with target=120 incorrectly corrected it to
+        136.55 (one-third), breaking timing alignment.
         """
-        self.assertEqual(_pick_best_tempo(180.0), 180.0)
+        self.assertAlmostEqual(_pick_best_tempo(409.66), 409.66)
 
-    def test_two_thirds_correction_out_of_range(self):
-        """270 BPM is above range. 270 * 2/3 = 180, in range."""
-        self.assertEqual(_pick_best_tempo(270.0), 135.0)  # half = 135, closer to 120
+    # -- out-of-range correction (values outside [50, 500]) -------------------
+
+    def test_very_high_bpm_corrected_to_half(self):
+        """800 BPM is above 500. Half = 400, in range and closest to 800."""
+        self.assertEqual(_pick_best_tempo(800.0), 400.0)
+
+    def test_very_low_bpm_corrected(self):
+        """25 BPM is below 50. Double = 50, in range and closest to 25."""
+        self.assertEqual(_pick_best_tempo(25.0), 50.0)
+
+    def test_extremely_high_bpm_uses_quarter(self):
+        """2000 BPM. Quarter = 500, in range and closest to 2000."""
+        self.assertEqual(_pick_best_tempo(2000.0), 500.0)
+
+    def test_very_low_bpm_prefers_closest_to_original(self):
+        """10 BPM: candidates 10, 5, 20, 3.3, 30, 2.5, 40, 6.7, 15, 7.5.
+
+        None in [50, 500] -- returns primary as-is.
+        """
+        self.assertEqual(_pick_best_tempo(10.0), 10.0)
+
+    # -- target=None uses primary as reference --------------------------------
+
+    def test_target_none_picks_closest_to_primary(self):
+        """With target=None, out-of-range correction picks the candidate
+        closest to the detected value, not closest to 120.
+
+        600 BPM -> candidates in [50, 500]:
+          half = 300 (distance 300), three-quarters = 450 (distance 150),
+          third = 200 (distance 400), quarter = 150 (distance 450).
+        450 wins (closest to 600).
+        """
+        self.assertEqual(_pick_best_tempo(600.0), 450.0)
+
+    def test_explicit_target_biases_selection(self):
+        """With an explicit target, the candidate closest to that target
+        is selected instead.
+
+        600 BPM with target=120: half = 300 (dist 180), third = 200
+        (dist 80), quarter = 150 (dist 30).  150 wins (closest to 120).
+        """
+        self.assertEqual(
+            _pick_best_tempo(600.0, target=120.0), 150.0
+        )
 
     # -- simpler ratios win ties ----------------------------------------------
 
     def test_simpler_ratio_wins_tie(self):
-        """When two candidates are equally close to 120, the simpler
+        """When two candidates are equally close to the reference, the simpler
         ratio (earlier in _TEMPO_RATIOS) should win.
 
-        Example: primary=120. Identity gives 120 (exact match).
-        Other ratios may also produce values, but identity wins.
+        600 BPM with target=350:
+          half  = 300 (ratio 0.5, distance |300-350| = 50)
+          2/3   = 400 (ratio 2/3, distance |400-350| = 50)
+        Both are in range and equidistant from target.  Half (0.5) is
+        listed before two-thirds (2/3) in _TEMPO_RATIOS, so 300 wins.
         """
-        self.assertEqual(_pick_best_tempo(120.0), 120.0)
-
-    # -- nothing in range falls back ------------------------------------------
-
-    def test_nothing_in_range_returns_primary(self):
-        """If no candidate falls in range, return the primary as-is."""
-        # 10 BPM: candidates are 10, 5, 20, 3.3, 30, 2.5, 40, 6.7, 15, 7.5
-        # None of these are in 60-200
-        self.assertEqual(_pick_best_tempo(10.0), 10.0)
+        self.assertEqual(
+            _pick_best_tempo(600.0, target=350.0), 300.0
+        )
 
     # -- custom range ---------------------------------------------------------
 
@@ -135,35 +171,29 @@ class TestPickBestTempo(unittest.TestCase):
 
     def test_result_in_range(self):
         """For typical inputs, the result should be within the default range."""
-        test_values = [75.0, 90.0, 110.0, 130.0, 150.0, 170.0, 200.0, 250.0, 300.0, 400.0]
+        test_values = [75.0, 90.0, 110.0, 130.0, 150.0, 170.0, 200.0,
+                       250.0, 300.0, 400.0, 500.0, 600.0, 800.0]
         for bpm in test_values:
             result = _pick_best_tempo(bpm)
             # Check that result is in range (if any candidate was in range)
             candidates = [bpm * r for r in _TEMPO_RATIOS]
-            has_candidate_in_range = any(60 <= c <= 200 for c in candidates)
+            has_candidate_in_range = any(50 <= c <= 500 for c in candidates)
             if has_candidate_in_range:
                 self.assertGreaterEqual(
-                    result, 60.0, f"Result {result} below range for input {bpm}"
+                    result, 50.0, f"Result {result} below range for input {bpm}"
                 )
                 self.assertLessEqual(
-                    result, 200.0, f"Result {result} above range for input {bpm}"
+                    result, 500.0, f"Result {result} above range for input {bpm}"
                 )
 
-    # -- backward compatibility: half/double still work -----------------------
+    # -- 180 BPM in-range check (unchanged from before) -----------------------
 
-    def test_backward_compat_half(self):
-        """Original half-tempo case still works."""
-        # 240 -> half = 120 (closest to target)
-        self.assertEqual(_pick_best_tempo(240.0), 120.0)
+    def test_180_bpm_in_range_not_rescaled(self):
+        """180 BPM is in range -- must NOT be rescaled.
 
-    def test_backward_compat_double(self):
-        """Original double-tempo case still works."""
-        # 55 -> double = 110 (in range, closest to target)
-        self.assertEqual(_pick_best_tempo(55.0), 110.0)
-
-    def test_backward_compat_in_range(self):
-        """Original in-range case still works."""
-        self.assertEqual(_pick_best_tempo(120.0), 120.0)
+        Legitimate fast songs should keep their detected tempo.
+        """
+        self.assertEqual(_pick_best_tempo(180.0), 180.0)
 
 
 if __name__ == "__main__":

--- a/pytest/modules/Midi/test_midi_creator.py
+++ b/pytest/modules/Midi/test_midi_creator.py
@@ -1,0 +1,177 @@
+"""Tests for midi_creator.py — global and local octave correction."""
+
+import unittest
+
+import librosa
+import numpy as np
+
+from src.modules.Midi.MidiSegment import MidiSegment
+from src.modules.Midi.midi_creator import (
+    correct_global_octave,
+    confidence_weighted_median_note,
+)
+
+
+class TestCorrectGlobalOctave(unittest.TestCase):
+    """Tests for correct_global_octave()."""
+
+    # -- edge cases ----------------------------------------------------------
+
+    def test_empty_list_returns_empty(self):
+        result = correct_global_octave([])
+        self.assertEqual(result, [])
+
+    def test_single_note_in_range_unchanged(self):
+        seg = MidiSegment(note="C4", start=0, end=1, word="hello ")
+        result = correct_global_octave([seg])
+        self.assertEqual(result[0].note, "C4")
+
+    # -- already in range (no shift) -----------------------------------------
+
+    def test_notes_in_range_unchanged(self):
+        """Notes whose median is inside 48-84 should not be shifted."""
+        segs = [
+            MidiSegment(note="C4", start=0, end=1, word="one "),   # MIDI 60
+            MidiSegment(note="E4", start=1, end=2, word="two "),   # MIDI 64
+            MidiSegment(note="G4", start=2, end=3, word="three "), # MIDI 67
+        ]
+        result = correct_global_octave(segs)
+        notes = [s.note for s in result]
+        self.assertEqual(notes, ["C4", "E4", "G4"])
+
+    # -- shift up (sub-harmonic detection) ------------------------------------
+
+    def test_all_notes_two_octaves_low_shifted_up(self):
+        """Median MIDI ~36 (C2) -> needs +24 shift to reach 48+ range."""
+        segs = [
+            MidiSegment(note="C2", start=0, end=1, word="a "),   # MIDI 36
+            MidiSegment(note="D2", start=1, end=2, word="b "),   # MIDI 38
+            MidiSegment(note="E2", start=2, end=3, word="c "),   # MIDI 40
+        ]
+        result = correct_global_octave(segs)
+        # All should be shifted up by +12 (one octave brings median to 48-50)
+        midi_values = [librosa.note_to_midi(s.note) for s in result]
+        for val in midi_values:
+            self.assertGreaterEqual(val, 48)
+            self.assertLessEqual(val, 84)
+
+    def test_all_notes_four_octaves_low_shifted_up(self):
+        """Simulate a real-world sub-harmonic detection problem: MIDI 21-26.
+
+        The function shifts all notes so the *median* lands inside the
+        vocal range.  Individual notes may still be below ``low`` if
+        they were already the lowest in the set.
+        """
+        segs = [
+            MidiSegment(note="D1", start=0, end=1, word="wake "),   # MIDI 26
+            MidiSegment(note="A0", start=1, end=2, word="me "),     # MIDI 21
+            MidiSegment(note="C1", start=2, end=3, word="up "),     # MIDI 24
+            MidiSegment(note="B0", start=3, end=4, word="in "),     # MIDI 23
+            MidiSegment(note="D1", start=4, end=5, word="side "),   # MIDI 26
+        ]
+        result = correct_global_octave(segs)
+        midi_values = [librosa.note_to_midi(s.note) for s in result]
+        median_after = float(np.median(midi_values))
+        # Median must be within the default vocal range
+        self.assertGreaterEqual(median_after, 48)
+        self.assertLessEqual(median_after, 84)
+        # All notes must have been shifted up (original median was 24)
+        for val in midi_values:
+            self.assertGreater(val, 24)
+
+    # -- shift down (over-detection) ------------------------------------------
+
+    def test_all_notes_above_range_shifted_down(self):
+        """Median MIDI ~96 (C7) -> needs shift down into range."""
+        segs = [
+            MidiSegment(note="C7", start=0, end=1, word="high "),   # MIDI 96
+            MidiSegment(note="D7", start=1, end=2, word="note "),   # MIDI 98
+            MidiSegment(note="E7", start=2, end=3, word="test "),   # MIDI 100
+        ]
+        result = correct_global_octave(segs)
+        midi_values = [librosa.note_to_midi(s.note) for s in result]
+        for val in midi_values:
+            self.assertLessEqual(val, 84)
+
+    # -- shift is always a multiple of 12 ------------------------------------
+
+    def test_shift_is_multiple_of_12(self):
+        """The shift must be a whole number of octaves (multiple of 12)."""
+        segs = [
+            MidiSegment(note="C2", start=0, end=1, word="lo "),  # MIDI 36
+            MidiSegment(note="G2", start=1, end=2, word="w "),   # MIDI 43
+        ]
+        original_midis = [librosa.note_to_midi(s.note) for s in segs]
+        result = correct_global_octave(segs)
+        shifted_midis = [librosa.note_to_midi(s.note) for s in result]
+
+        for orig, shifted in zip(original_midis, shifted_midis, strict=True):
+            self.assertEqual((shifted - orig) % 12, 0)
+
+    # -- custom range ---------------------------------------------------------
+
+    def test_custom_range(self):
+        """Custom low/high should be respected."""
+        segs = [
+            MidiSegment(note="C4", start=0, end=1, word="mid "),  # MIDI 60
+        ]
+        # With a very narrow high range, C4 (60) is above high=55
+        result = correct_global_octave(segs, low=40, high=55)
+        midi_val = librosa.note_to_midi(result[0].note)
+        self.assertLessEqual(midi_val, 55)
+
+    # -- preserves relative intervals -----------------------------------------
+
+    def test_relative_intervals_preserved(self):
+        """After shift, the intervals between notes must be identical."""
+        segs = [
+            MidiSegment(note="C2", start=0, end=1, word="do "),   # MIDI 36
+            MidiSegment(note="E2", start=1, end=2, word="mi "),   # MIDI 40
+            MidiSegment(note="G2", start=2, end=3, word="sol "),  # MIDI 43
+        ]
+        original_midis = [librosa.note_to_midi(s.note) for s in segs]
+        original_intervals = [
+            original_midis[i + 1] - original_midis[i]
+            for i in range(len(original_midis) - 1)
+        ]
+
+        result = correct_global_octave(segs)
+        shifted_midis = [librosa.note_to_midi(s.note) for s in result]
+        shifted_intervals = [
+            shifted_midis[i + 1] - shifted_midis[i]
+            for i in range(len(shifted_midis) - 1)
+        ]
+
+        self.assertEqual(original_intervals, shifted_intervals)
+
+
+class TestConfidenceWeightedMedianNote(unittest.TestCase):
+    """Tests for confidence_weighted_median_note()."""
+
+    def test_single_frequency(self):
+        note = confidence_weighted_median_note([440.0], [1.0])
+        self.assertEqual(note, "A4")
+
+    def test_empty_raises(self):
+        with self.assertRaises(ValueError):
+            confidence_weighted_median_note([], [])
+
+    def test_mismatched_lengths_raises(self):
+        with self.assertRaises(ValueError):
+            confidence_weighted_median_note([440.0, 880.0], [1.0])
+
+    def test_zero_weights_raises(self):
+        with self.assertRaises(ValueError):
+            confidence_weighted_median_note([440.0], [0.0])
+
+    def test_high_confidence_dominates(self):
+        """A single high-confidence frame should dominate low-confidence noise."""
+        freqs = [440.0, 220.0, 220.0, 220.0]
+        weights = [0.95, 0.1, 0.1, 0.1]
+        note = confidence_weighted_median_note(freqs, weights)
+        # The high-weight A4 (440 Hz) should win
+        self.assertEqual(note, "A4")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pytest/modules/Midi/test_midi_creator.py
+++ b/pytest/modules/Midi/test_midi_creator.py
@@ -8,6 +8,7 @@ import numpy as np
 from src.modules.Midi.MidiSegment import MidiSegment
 from src.modules.Midi.midi_creator import (
     correct_global_octave,
+    correct_octave_outliers,
     confidence_weighted_median_note,
 )
 
@@ -143,6 +144,233 @@ class TestCorrectGlobalOctave(unittest.TestCase):
         ]
 
         self.assertEqual(original_intervals, shifted_intervals)
+
+
+class TestCorrectOctaveOutliers(unittest.TestCase):
+    """Tests for correct_octave_outliers() — single and multi-pass."""
+
+    # -- helpers --------------------------------------------------------------
+
+    @staticmethod
+    def _make_segs(notes: list[str]) -> list[MidiSegment]:
+        """Create MidiSegments from a list of note names."""
+        return [
+            MidiSegment(note=n, start=float(i), end=float(i + 1), word=f"w{i} ")
+            for i, n in enumerate(notes)
+        ]
+
+    @staticmethod
+    def _get_notes(segs: list[MidiSegment]) -> list[str]:
+        return [s.note for s in segs]
+
+    @staticmethod
+    def _get_midis(segs: list[MidiSegment]) -> list[int]:
+        return [librosa.note_to_midi(s.note) for s in segs]
+
+    # -- edge cases -----------------------------------------------------------
+
+    def test_empty_list_returns_empty(self):
+        result = correct_octave_outliers([])
+        self.assertEqual(result, [])
+
+    def test_two_notes_unchanged(self):
+        """Less than 3 notes should be returned unchanged."""
+        segs = self._make_segs(["C4", "E4"])
+        result = correct_octave_outliers(segs)
+        self.assertEqual(self._get_notes(result), ["C4", "E4"])
+
+    # -- single outlier (works with one pass) ---------------------------------
+
+    def test_single_outlier_corrected(self):
+        """One note an octave too low among correct neighbours."""
+        # C4=60, C4, C2=36(!), C4, C4
+        notes = ["C4", "C4", "C2", "C4", "C4"]
+        segs = self._make_segs(notes)
+        result = correct_octave_outliers(segs, passes=1)
+        midis = self._get_midis(result)
+        # C2 (36) should be corrected to C4 (60)
+        self.assertEqual(midis[2], 60)
+
+    def test_single_outlier_above_corrected(self):
+        """One note an octave too high among correct neighbours."""
+        # C4=60, C4, C6=84(!), C4, C4
+        notes = ["C4", "C4", "C6", "C4", "C4"]
+        segs = self._make_segs(notes)
+        result = correct_octave_outliers(segs, passes=1)
+        midis = self._get_midis(result)
+        # C6 (84) should be corrected to C4 (60)
+        self.assertEqual(midis[2], 60)
+
+    # -- cluster of wrong-octave notes (needs multiple passes) ----------------
+
+    def test_cluster_of_wrong_octave_notes_corrected(self):
+        """A cluster of 8 sub-harmonic notes surrounded by correct notes.
+
+        Single pass cannot fix the cluster because the local median
+        within the cluster is also wrong.  Two passes should correct
+        all notes.
+        """
+        # 6x C4, then 8x C3 (one octave too low), then 6x C4
+        correct = ["C4"] * 6
+        cluster = ["C3"] * 8
+        notes = correct + cluster + correct
+        segs = self._make_segs(notes)
+
+        result = correct_octave_outliers(segs, passes=2)
+        midis = self._get_midis(result)
+
+        # All notes should now be C4 (MIDI 60)
+        for i, midi_val in enumerate(midis):
+            self.assertEqual(
+                midi_val, 60,
+                f"Note {i} is MIDI {midi_val}, expected 60 (C4)"
+            )
+
+    def test_two_passes_fixes_more_than_one(self):
+        """Verify that a second pass corrects notes left behind by pass 1.
+
+        With window=3, a cluster of 5 wrong notes surrounded by 4 correct
+        on each side cannot be fully fixed in one pass.
+        """
+        correct = ["E4"] * 4  # MIDI 64
+        cluster = ["E3"] * 5  # MIDI 52, one octave low
+        notes = correct + cluster + correct
+        segs = self._make_segs(notes)
+
+        # One pass with small window - may not fix the inner cluster notes
+        result_1pass = correct_octave_outliers(
+            self._make_segs(notes), passes=1, window=3
+        )
+        midis_1pass = self._get_midis(result_1pass)
+        unfixed_1pass = sum(1 for v in midis_1pass if v == 52)
+
+        # Two passes should fix more (or all)
+        result_2pass = correct_octave_outliers(segs, passes=2, window=3)
+        midis_2pass = self._get_midis(result_2pass)
+        unfixed_2pass = sum(1 for v in midis_2pass if v == 52)
+
+        self.assertLessEqual(
+            unfixed_2pass, unfixed_1pass,
+            "Two passes should fix at least as many outliers as one pass"
+        )
+
+    # -- passes=1 backward compatibility --------------------------------------
+
+    def test_passes_1_backward_compatible(self):
+        """passes=1 should behave identically to the old single-pass code."""
+        notes = ["C4", "C4", "C2", "C4", "C4"]
+        segs = self._make_segs(notes)
+        result = correct_octave_outliers(segs, passes=1)
+        midis = self._get_midis(result)
+        self.assertEqual(midis[2], 60)  # C2 -> C4
+
+    # -- global median tie-breaker --------------------------------------------
+
+    def test_global_median_tiebreaker(self):
+        """When multiple octave shifts are valid, prefer the one closest
+        to the global median.
+
+        All notes are around C4 (60) except one outlier at C2 (36).
+        Both C4 (60) and C6 (84) could bring C2 within 11 ST of the
+        local median.  C4 is closer to the global median (~60), so
+        C4 should be chosen.
+        """
+        notes = ["C4", "D4", "E4", "C2", "D4", "E4", "C4"]
+        segs = self._make_segs(notes)
+        result = correct_octave_outliers(segs, passes=1)
+        midis = self._get_midis(result)
+        # C2 (36) should become C4 (60), not C6 (84)
+        self.assertEqual(midis[3], 60)
+
+    # -- early termination when no corrections --------------------------------
+
+    def test_early_termination_no_changes(self):
+        """If all notes are already correct, no corrections should happen
+        and the function should terminate early.
+        """
+        notes = ["C4", "D4", "E4", "F4", "G4"]
+        segs = self._make_segs(notes)
+        result = correct_octave_outliers(segs, passes=5)
+        self.assertEqual(self._get_notes(result), notes)
+
+    # -- preserves non-outlier notes ------------------------------------------
+
+    def test_correct_notes_unchanged(self):
+        """Notes that are not outliers should remain exactly unchanged."""
+        notes = ["C4", "E4", "G4", "C2", "E4", "G4", "C4"]
+        segs = self._make_segs(notes)
+        original_correct = [60, 64, 67, None, 64, 67, 60]
+
+        result = correct_octave_outliers(segs)
+        midis = self._get_midis(result)
+
+        for i, expected in enumerate(original_correct):
+            if expected is not None:
+                self.assertEqual(
+                    midis[i], expected,
+                    f"Note {i} changed from {expected} to {midis[i]}"
+                )
+
+    # -- valid minority melody note preserved ---------------------------------
+
+    def test_valid_melody_note_preserved_by_consensus(self):
+        """G4 (MIDI 67) is 7 ST from global median C4 (60).
+
+        Phase 2 must NOT shift it — it is a valid melody interval,
+        not an octave error.  Only notes ≥ 12 ST away should be touched.
+        """
+        # 6x C4, 1x G4, 6x C4  → global median ≈ 60
+        notes = ["C4"] * 6 + ["G4"] + ["C4"] * 6
+        segs = self._make_segs(notes)
+        result = correct_octave_outliers(segs, passes=2)
+        midis = self._get_midis(result)
+        # G4 (67) must remain unchanged
+        self.assertEqual(midis[6], 67, "G4 was incorrectly shifted by consensus")
+
+    def test_phase1_and_phase2_cooperate(self):
+        """Phase 1 (local) and Phase 2 (global consensus) each fix
+        a different kind of outlier.
+
+        Setup: 6x C4, 8x C3 (cluster — too large for local fix),
+               1x C2 (isolated — fixed by Phase 1), 6x C4.
+        Phase 1 corrects C2 → C4 (24 ST from local median, clear outlier).
+        Phase 2 corrects the C3 cluster → C4 (12 ST from global median=60,
+        local windows are contaminated so Phase 1 can't help).
+        """
+        notes = ["C4"] * 6 + ["C3"] * 8 + ["C2"] + ["C4"] * 6
+        segs = self._make_segs(notes)
+        result = correct_octave_outliers(segs, passes=2)
+        midis = self._get_midis(result)
+        # C2 (index 14) should be fixed by Phase 1
+        self.assertEqual(midis[14], 60, "Isolated C2 not fixed by Phase 1")
+        # C3 cluster (indices 6-13) should be fixed by Phase 2
+        for i in range(6, 14):
+            self.assertEqual(
+                midis[i], 60,
+                f"Cluster note {i} is MIDI {midis[i]}, expected 60 (C4)"
+            )
+        # Boundary C4s must remain unchanged
+        for i in list(range(0, 6)) + list(range(15, 21)):
+            self.assertEqual(
+                midis[i], 60,
+                f"Boundary note {i} is MIDI {midis[i]}, expected 60 (C4)"
+            )
+
+    # -- shift is always a multiple of 12 ------------------------------------
+
+    def test_shifts_are_octave_multiples(self):
+        """Any correction must be an exact octave shift (multiple of 12)."""
+        notes = ["C4", "C4", "C2", "C4", "C4", "C6", "C4", "C4"]
+        original = [60, 60, 36, 60, 60, 84, 60, 60]
+        segs = self._make_segs(notes)
+        result = correct_octave_outliers(segs)
+        midis = self._get_midis(result)
+
+        for i, (orig, new) in enumerate(zip(original, midis)):
+            self.assertEqual(
+                (new - orig) % 12, 0,
+                f"Note {i}: shift {new - orig} is not a multiple of 12"
+            )
 
 
 class TestConfidenceWeightedMedianNote(unittest.TestCase):

--- a/pytest/modules/Midi/test_midi_creator.py
+++ b/pytest/modules/Midi/test_midi_creator.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from src.modules.Midi.MidiSegment import MidiSegment
 from src.modules.Midi.midi_creator import (
+    apply_octave_shift,
     correct_global_octave,
     correct_octave_outliers,
     confidence_weighted_median_note,
@@ -371,6 +372,104 @@ class TestCorrectOctaveOutliers(unittest.TestCase):
                 (new - orig) % 12, 0,
                 f"Note {i}: shift {new - orig} is not a multiple of 12"
             )
+
+
+class TestApplyOctaveShift(unittest.TestCase):
+    """Tests for apply_octave_shift()."""
+
+    def _make_seg(self, note, start=0, end=1, word="x "):
+        return MidiSegment(note=note, start=start, end=end, word=word)
+
+    def _get_midis(self, segs):
+        return [librosa.note_to_midi(s.note) for s in segs]
+
+    # -- edge cases ----------------------------------------------------------
+
+    def test_empty_list_returns_empty(self):
+        result = apply_octave_shift([], 1)
+        self.assertEqual(result, [])
+
+    def test_zero_shift_unchanged(self):
+        segs = [self._make_seg("C4"), self._make_seg("E4")]
+        result = apply_octave_shift(segs, 0)
+        self.assertEqual([s.note for s in result], ["C4", "E4"])
+
+    def test_none_octaves_unchanged(self):
+        """Calling with octaves=0 should be a no-op."""
+        segs = [self._make_seg("C4")]
+        original_note = segs[0].note
+        apply_octave_shift(segs, 0)
+        self.assertEqual(segs[0].note, original_note)
+
+    # -- shift up ------------------------------------------------------------
+
+    def test_shift_up_one_octave(self):
+        segs = [self._make_seg("C3"), self._make_seg("E3"), self._make_seg("G3")]
+        result = apply_octave_shift(segs, 1)
+        self.assertEqual([s.note for s in result], ["C4", "E4", "G4"])
+
+    def test_shift_up_two_octaves(self):
+        segs = [self._make_seg("C2")]
+        result = apply_octave_shift(segs, 2)
+        self.assertEqual(result[0].note, "C4")
+
+    # -- shift down ----------------------------------------------------------
+
+    def test_shift_down_one_octave(self):
+        segs = [self._make_seg("C5"), self._make_seg("E5")]
+        result = apply_octave_shift(segs, -1)
+        self.assertEqual([s.note for s in result], ["C4", "E4"])
+
+    def test_shift_down_two_octaves(self):
+        segs = [self._make_seg("C6")]
+        result = apply_octave_shift(segs, -2)
+        self.assertEqual(result[0].note, "C4")
+
+    # -- MIDI range clamping -------------------------------------------------
+
+    def test_shift_up_beyond_127_skipped(self):
+        """Notes that would exceed MIDI 127 should be left unchanged."""
+        segs = [self._make_seg("G9")]  # MIDI 127
+        result = apply_octave_shift(segs, 1)
+        # G9 + 12 = MIDI 139 > 127, should stay G9
+        self.assertEqual(result[0].note, "G9")
+
+    def test_shift_down_below_0_skipped(self):
+        """Notes that would go below MIDI 0 should be left unchanged."""
+        segs = [self._make_seg("C0")]  # MIDI ~12
+        result = apply_octave_shift(segs, -2)
+        # C0 - 24 = MIDI -12 < 0, should stay C0
+        self.assertEqual(result[0].note, "C0")
+
+    # -- modifies in-place ---------------------------------------------------
+
+    def test_modifies_in_place(self):
+        segs = [self._make_seg("C3")]
+        apply_octave_shift(segs, 1)
+        self.assertEqual(segs[0].note, "C4")
+
+    # -- preserves word and timing -------------------------------------------
+
+    def test_preserves_word_and_timing(self):
+        seg = self._make_seg("C3", start=1.5, end=2.5, word="hello ")
+        apply_octave_shift([seg], 1)
+        self.assertEqual(seg.word, "hello ")
+        self.assertEqual(seg.start, 1.5)
+        self.assertEqual(seg.end, 2.5)
+
+    # -- mixed notes ---------------------------------------------------------
+
+    def test_shift_preserves_intervals(self):
+        """Shifting should preserve all intervals between notes."""
+        segs = [self._make_seg("C3"), self._make_seg("E3"), self._make_seg("G3")]
+        midis_before = self._get_midis(segs)
+        intervals_before = [midis_before[i+1] - midis_before[i] for i in range(len(midis_before)-1)]
+
+        apply_octave_shift(segs, 1)
+
+        midis_after = self._get_midis(segs)
+        intervals_after = [midis_after[i+1] - midis_after[i] for i in range(len(midis_after)-1)]
+        self.assertEqual(intervals_before, intervals_after)
 
 
 class TestConfidenceWeightedMedianNote(unittest.TestCase):

--- a/pytest/modules/Pitcher/test_pitcher.py
+++ b/pytest/modules/Pitcher/test_pitcher.py
@@ -9,7 +9,7 @@ from src.modules.plot import plot
 
 class PitcherTest(unittest.TestCase):
     @pytest.mark.skip(reason="Skipping this FUNCTION level test, can be used for manual tests")
-    def test_get_pitch_with_crepe_file(self):
+    def test_get_pitch_with_file(self):
         # Arrange
         test_dir = os.path.dirname(os.path.abspath(__file__))
         root_dir = os.path.abspath(test_dir + "/../../..")
@@ -19,7 +19,7 @@ class PitcherTest(unittest.TestCase):
 
         # Act
         pitched_data = test_subject.get_pitch_with_file(test_file_abs_path)
-        # test_subject.get_pitch_with_crepe_file(test_file_abs_path, 'full', 'cpu', batch_size=1024)
+        # test_subject.get_pitch_with_file(test_file_abs_path)
         plot(pitched_data, test_output, title="pitching test")
         print("done")
 

--- a/pytest/modules/UltraStar/test_ultrastar_writer.py
+++ b/pytest/modules/UltraStar/test_ultrastar_writer.py
@@ -120,13 +120,13 @@ class TestCreateUltrastarTxt(unittest.TestCase):
             if default_ultrastar_class.videoUrl is not None:
                 expected_calls += [f"#{UltrastarTxtTag.VIDEOURL.value}:{default_ultrastar_class.videoUrl}\n"]
         expected_calls += [
-            f"#{UltrastarTxtTag.BPM.value}:390.0\n",
+            f"#{UltrastarTxtTag.BPM.value}:420.0\n",
             f"#{UltrastarTxtTag.GAP.value}:500\n",
             f"#{UltrastarTxtTag.CREATOR.value}:{default_ultrastar_class.creator}\n",
             f"#{UltrastarTxtTag.COMMENT.value}:{default_ultrastar_class.comment}\n",
-            ": 0 52 1 UltraSinger \n",
-            ": 65 39 2 is \n",
-            ": 130 52 3 cool! \n",
+            ": 0 56 1 UltraSinger \n",
+            ": 70 42 2 is \n",
+            ": 140 56 3 cool! \n",
             "E"
         ]
 
@@ -151,15 +151,15 @@ class TestCreateUltrastarTxt(unittest.TestCase):
         expected_calls.append(f"#{UltrastarTxtTag.VIDEO.value}:{default_ultrastar_class.video}\n")
         if version.parse(ver) >= version.parse("1.2.0"):
             expected_calls.append(f"#{UltrastarTxtTag.VIDEOURL.value}:{default_ultrastar_class.videoUrl}\n")
-        expected_calls.append(f"#{UltrastarTxtTag.BPM.value}:390.0\n")
+        expected_calls.append(f"#{UltrastarTxtTag.BPM.value}:420.0\n")
         expected_calls.append(f"#{UltrastarTxtTag.GAP.value}:500\n")
         if version.parse(ver) >= version.parse("1.1.0"):
             expected_calls.append(f"#{UltrastarTxtTag.TAGS.value}:{default_ultrastar_class.tags}\n")
         expected_calls.append(f"#{UltrastarTxtTag.CREATOR.value}:{default_ultrastar_class.creator}\n")
         expected_calls.append(f"#{UltrastarTxtTag.COMMENT.value}:{default_ultrastar_class.comment}\n")
-        expected_calls.append(": 0 52 1 UltraSinger \n")
-        expected_calls.append(": 65 39 2 is \n")
-        expected_calls.append(": 130 52 3 cool! \n")
+        expected_calls.append(": 0 56 1 UltraSinger \n")
+        expected_calls.append(": 70 42 2 is \n")
+        expected_calls.append(": 140 56 3 cool! \n")
         expected_calls.append("E")
 
         return expected_calls

--- a/pytest/modules/UltraStar/test_ultrastar_writer.py
+++ b/pytest/modules/UltraStar/test_ultrastar_writer.py
@@ -244,8 +244,8 @@ class TestCreateUltrastarTxt(unittest.TestCase):
                0.03999999999999204, 0.14000000000001478, 0.040000000000020464, 0.04099999999999682,
                0.040000000000020464, 0.040000000000020464]
 
-        # Act
-        result = silence_threshold(val)
+        # Act — use explicit percentile=75 for this regression dataset
+        result = silence_threshold(val, percentile=75)
 
         # Assert — 75th percentile ≈ 0.12
         self.assertAlmostEqual(result, 0.12, places=2)
@@ -299,8 +299,8 @@ class TestCreateUltrastarTxt(unittest.TestCase):
                0.020000000000010232, 0.15500000000000114, 0.9489999999999839, 0.040000000000020464, 0.0,
                0.03999999999999204, 0.040000000000020464, 0.14500000000001023]
 
-        # Act
-        result = silence_threshold(val)
+        # Act — use explicit percentile=75 for this regression dataset
+        result = silence_threshold(val, percentile=75)
 
         # Assert — 75th percentile ≈ 0.08
         self.assertAlmostEqual(result, 0.08, places=2)
@@ -353,8 +353,8 @@ class TestCreateUltrastarTxt(unittest.TestCase):
                0.12000000000000455, 0.6200000000000045, 0.09999999999999432, 6.356999999999999, 0.03999999999999204,
                0.14099999999999113]
 
-        # Act
-        result = silence_threshold(val)
+        # Act — use explicit percentile=75 for this regression dataset
+        result = silence_threshold(val, percentile=75)
 
         # Assert — 75th percentile ≈ 0.18
         self.assertAlmostEqual(result, 0.18, places=1)
@@ -432,8 +432,8 @@ class TestCreateUltrastarTxt(unittest.TestCase):
                0.060000000000002274, 0.0, 0.05999999999997385, 0.040000000000020464, 0.060000000000002274, 0.0,
                0.060000000000002274, 0.01999999999998181]
 
-        # Act
-        result = silence_threshold(val)
+        # Act — use explicit percentile=75 for this regression dataset
+        result = silence_threshold(val, percentile=75)
 
         # Assert — 75th percentile ≈ 0.04
         self.assertAlmostEqual(result, 0.04, places=2)
@@ -444,6 +444,26 @@ class TestCreateUltrastarTxt(unittest.TestCase):
         self.assertEqual(format_separated_string('rock/pop/rock-pop,'), 'Rock, Pop, Rock-Pop')
         self.assertEqual(format_separated_string('rock,pop/rock-pop;80s,'), 'Rock, Pop, Rock-Pop, 80s')
         self.assertEqual(format_separated_string('rock, pop, rock-pop, '), 'Rock, Pop, Rock-Pop')
+
+    def test_silence_threshold_default_is_85th_percentile(self):
+        """The default percentile (85) should produce a higher threshold
+        than the 75th percentile, resulting in fewer linebreaks."""
+        gaps = [0.01, 0.02, 0.03, 0.04, 0.05,
+                0.10, 0.20, 0.50, 1.00, 2.00]
+        result_default = silence_threshold(gaps)           # percentile=85
+        result_75 = silence_threshold(gaps, percentile=75)
+        self.assertIsNotNone(result_default)
+        self.assertIsNotNone(result_75)
+        self.assertGreater(result_default, result_75)
+
+    def test_silence_threshold_explicit_percentile(self):
+        """Passing an explicit percentile overrides the default."""
+        gaps = [0.0, 0.1, 0.2, 0.3, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0]
+        result_50 = silence_threshold(gaps, percentile=50)
+        result_90 = silence_threshold(gaps, percentile=90)
+        self.assertIsNotNone(result_50)
+        self.assertIsNotNone(result_90)
+        self.assertGreater(result_90, result_50)
 
     def test_silence_threshold_short_input_returns_none(self):
         """Fewer than 5 gaps should return None (not enough data)."""

--- a/pytest/modules/UltraStar/test_ultrastar_writer.py
+++ b/pytest/modules/UltraStar/test_ultrastar_writer.py
@@ -4,7 +4,10 @@ import unittest
 
 from packaging import version
 from unittest.mock import patch, mock_open
-from src.modules.Ultrastar.ultrastar_writer import create_ultrastar_txt, deviation, format_separated_string
+from src.modules.Ultrastar.ultrastar_writer import (
+    create_ultrastar_txt, silence_threshold, calculate_silent_beat_length,
+    format_separated_string,
+)
 from src.modules.Midi.MidiSegment import MidiSegment
 from src.modules.Ultrastar.ultrastar_txt import UltrastarTxtValue, UltrastarTxtTag
 
@@ -242,11 +245,10 @@ class TestCreateUltrastarTxt(unittest.TestCase):
                0.040000000000020464, 0.040000000000020464]
 
         # Act
-        result = deviation(val)
+        result = silence_threshold(val)
 
-        # Assert
-        self.assertLessEqual(result, 0.45)
-        self.assertGreaterEqual(result, 0.37)
+        # Assert — 75th percentile ≈ 0.12
+        self.assertAlmostEqual(result, 0.12, places=2)
 
     def test_most_common_silent_part_AnenRegnen(self):
         # Arrange
@@ -298,11 +300,10 @@ class TestCreateUltrastarTxt(unittest.TestCase):
                0.03999999999999204, 0.040000000000020464, 0.14500000000001023]
 
         # Act
-        result = deviation(val)
+        result = silence_threshold(val)
 
-        # Assert
-        self.assertGreaterEqual(result, 0.15)
-        self.assertLessEqual(result, 0.35)
+        # Assert — 75th percentile ≈ 0.08
+        self.assertAlmostEqual(result, 0.08, places=2)
 
     def test_most_common_silent_part_discw(self):
         # Arrange
@@ -353,11 +354,10 @@ class TestCreateUltrastarTxt(unittest.TestCase):
                0.14099999999999113]
 
         # Act
-        result = deviation(val)
+        result = silence_threshold(val)
 
-        # Assert
-        self.assertGreaterEqual(result, 0.24)
-        self.assertLessEqual(result, 0.43)
+        # Assert — 75th percentile ≈ 0.18
+        self.assertAlmostEqual(result, 0.18, places=1)
 
     def test_most_common_silent_part_kumr(self):
         # Arrange
@@ -433,11 +433,10 @@ class TestCreateUltrastarTxt(unittest.TestCase):
                0.060000000000002274, 0.01999999999998181]
 
         # Act
-        result = deviation(val)
+        result = silence_threshold(val)
 
-        # Assert
-        self.assertGreaterEqual(result, 0.11)
-        self.assertLessEqual(result, 0.168)
+        # Assert — 75th percentile ≈ 0.04
+        self.assertAlmostEqual(result, 0.04, places=2)
 
     def test_format_separated_string(self):
         self.assertEqual(format_separated_string('rock,pop,rock-pop,'), 'Rock, Pop, Rock-Pop')
@@ -445,6 +444,40 @@ class TestCreateUltrastarTxt(unittest.TestCase):
         self.assertEqual(format_separated_string('rock/pop/rock-pop,'), 'Rock, Pop, Rock-Pop')
         self.assertEqual(format_separated_string('rock,pop/rock-pop;80s,'), 'Rock, Pop, Rock-Pop, 80s')
         self.assertEqual(format_separated_string('rock, pop, rock-pop, '), 'Rock, Pop, Rock-Pop')
+
+    def test_silence_threshold_short_input_returns_none(self):
+        """Fewer than 5 gaps should return None (not enough data)."""
+        self.assertIsNone(silence_threshold([]))
+        self.assertIsNone(silence_threshold([0.1]))
+        self.assertIsNone(silence_threshold([0.1, 0.2, 0.3, 0.4]))
+
+    def test_calculate_silent_beat_length_few_segments(self):
+        """With < 6 segments (producing < 5 gaps), should return None."""
+        segments = [
+            MidiSegment(note="C4", start=0.0, end=0.5, word="a "),
+            MidiSegment(note="D4", start=1.0, end=1.5, word="b "),
+            MidiSegment(note="E4", start=2.0, end=2.5, word="c "),
+        ]
+        result = calculate_silent_beat_length(segments)
+        self.assertIsNone(result)
+
+    def test_calculate_silent_beat_length_clamps_negative_gaps(self):
+        """Overlapping segments should produce 0-clamped gaps, not negatives."""
+        # 8 segments → 7 gaps, some overlapping (negative raw gap)
+        segments = [
+            MidiSegment(note="C4", start=0.0, end=1.0, word="a "),
+            MidiSegment(note="D4", start=0.8, end=1.5, word="b "),   # overlaps: -0.2 → 0
+            MidiSegment(note="E4", start=2.0, end=2.5, word="c "),
+            MidiSegment(note="F4", start=3.0, end=3.5, word="d "),
+            MidiSegment(note="G4", start=4.0, end=4.5, word="e "),
+            MidiSegment(note="A4", start=5.0, end=5.5, word="f "),
+            MidiSegment(note="B4", start=6.0, end=6.5, word="g "),
+            MidiSegment(note="C5", start=7.0, end=7.5, word="h "),
+        ]
+        result = calculate_silent_beat_length(segments)
+        # All gaps are 0.5 except the overlap (0.0), so percentile must be >= 0
+        self.assertIsNotNone(result)
+        self.assertGreaterEqual(result, 0)
 
 
 if __name__ == "__main__":

--- a/pytest/tools/test_compare_ultrastar.py
+++ b/pytest/tools/test_compare_ultrastar.py
@@ -164,6 +164,22 @@ class TestVersionGe:
         """Malformed version string returns False gracefully."""
         assert _version_ge("abc", "1.2.0") is False
 
+    def test_shorthand_version_padded(self):
+        """Shorthand '1.2' is treated as '1.2.0' (padded with trailing zeros)."""
+        assert _version_ge("1.2", "1.2.0") is True
+        assert _version_ge("1.2.0", "1.2") is True
+
+    def test_suffixed_version_parsed(self):
+        """Suffixed versions like '1.2.0-beta' extract numeric part correctly."""
+        assert _version_ge("1.2.0-beta", "1.2.0") is True
+        assert _version_ge("1.3.0-rc1", "1.2.0") is True
+        assert _version_ge("1.1.0-alpha", "1.2.0") is False
+
+    def test_single_component_version(self):
+        """Single-component version like '2' is treated as '2.0.0'."""
+        assert _version_ge("2", "1.2.0") is True
+        assert _version_ge("1", "1.2.0") is False
+
 
 # ── Beat-to-ms conversion ───────────────────────────────────────────────────
 
@@ -212,7 +228,7 @@ class TestTildeGrouping:
         )
 
     def test_tilde_groups_with_parent(self):
-        """Tilde notes are appended to the preceding word group."""
+        """Tilde notes merge continuation text into the parent word."""
         notes = [
             self._make_note("Hel", start_ms=0, end_ms=100),
             self._make_note("~lo", start_ms=100, end_ms=200),
@@ -220,14 +236,14 @@ class TestTildeGrouping:
         ]
         groups = _group_words(notes)
         assert len(groups) == 2
-        assert groups[0].word == "Hel"
+        assert groups[0].word == "Hello"  # merged: "Hel" + "lo"
         assert len(groups[0].notes) == 2
         assert groups[0].end_ms == 200  # extended by tilde note
         assert groups[1].word == "World"
         assert len(groups[1].notes) == 1
 
     def test_multiple_tildes(self):
-        """Multiple consecutive tildes all attach to the same parent."""
+        """Multiple consecutive tildes all merge into the same parent."""
         notes = [
             self._make_note("Beau", start_ms=0, end_ms=50),
             self._make_note("~ti", start_ms=50, end_ms=100),
@@ -235,6 +251,7 @@ class TestTildeGrouping:
         ]
         groups = _group_words(notes)
         assert len(groups) == 1
+        assert groups[0].word == "Beautiful"  # merged: "Beau" + "ti" + "ful"
         assert len(groups[0].notes) == 3
         assert groups[0].end_ms == 150
 
@@ -674,6 +691,55 @@ class TestEdgeCases:
         """Normal percentage calculation works correctly."""
         assert _pct(1, 4) == 25.0
         assert _pct(3, 3) == 100.0
+
+    def test_lyrics_denominator_excludes_empty_words(self, tmp_path):
+        """Lyrics precision/recall denominators exclude empty normalized words.
+
+        align_words() filters out empty words, so denominators must use
+        the same filter to avoid underreporting metrics.
+        """
+        gen_txt = _write_ultrastar(tmp_path, """\
+            #TITLE:Test
+            #ARTIST:Test
+            #BPM:300
+            #GAP:0
+            : 0 5 60 Hello
+            : 10 5 60 -
+            : 20 5 62 World
+            E
+        """, name="gen.txt")
+
+        ref_txt = _write_ultrastar(tmp_path, """\
+            #TITLE:Test
+            #ARTIST:Test
+            #BPM:300
+            #GAP:0
+            : 0 5 60 Hello
+            : 20 5 62 World
+            E
+        """, name="ref.txt")
+
+        result = compare(gen_txt, ref_txt)
+        # "-" normalizes to "" → excluded from denominators
+        # gen has 2 valid words (Hello, World), ref has 2
+        assert result.gen_word_count == 2
+        assert result.ref_word_count == 2
+        assert result.matched_pairs == 2
+        assert result.lyrics_precision == 100.0
+        assert result.lyrics_recall == 100.0
+
+    def test_tilde_bare_continuation_no_suffix(self):
+        """Bare tilde '~' (no suffix text) does not alter parent word."""
+        notes = [
+            Note(note_type=":", start_beat=0, duration=5, pitch=60,
+                 midi=60, word="Hold", start_ms=0, end_ms=100),
+            Note(note_type=":", start_beat=5, duration=5, pitch=60,
+                 midi=60, word="~", start_ms=100, end_ms=200),
+        ]
+        groups = _group_words(notes)
+        assert len(groups) == 1
+        assert groups[0].word == "Hold"  # unchanged — "~" has no suffix
+        assert len(groups[0].notes) == 2
 
     def test_empty_file(self, tmp_path):
         """An empty file should parse without crashing."""

--- a/pytest/tools/test_compare_ultrastar.py
+++ b/pytest/tools/test_compare_ultrastar.py
@@ -1,0 +1,684 @@
+"""Tests for tools/compare_ultrastar.py — format-aware UltraStar comparison tool."""
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# The tool is a standalone script in tools/ — import its internals directly
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+
+from compare_ultrastar import (
+    Note,
+    WordGroup,
+    ParsedFile,
+    ComparisonResult,
+    _beat_to_ms,
+    _pitch_to_midi,
+    _version_ge,
+    _group_words,
+    _normalise_word,
+    _parse_bpm,
+    _parse_gap,
+    _pct,
+    align_words,
+    compare,
+    parse_ultrastar,
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _write_ultrastar(tmp_path: Path, content: str, name: str = "song.txt") -> Path:
+    """Write an UltraStar TXT file and return its path."""
+    p = tmp_path / name
+    p.write_text(textwrap.dedent(content), encoding="utf-8")
+    return p
+
+
+# ── Format detection ─────────────────────────────────────────────────────────
+
+class TestFormatDetection:
+    """Feature: auto-detect file format version and apply pitch conversion."""
+
+    def test_v120_format_detected(self, tmp_path):
+        """v1.2.0 header is parsed and pitch is offset by +48 to get MIDI."""
+        txt = _write_ultrastar(tmp_path, """\
+            #VERSION:1.2.0
+            #TITLE:Test
+            #ARTIST:Test
+            #BPM:300
+            #GAP:5000
+            : 0 5 12 Hello
+            E
+        """)
+        parsed = parse_ultrastar(txt)
+        assert parsed.version == "1.2.0"
+        # pitch=12 in v1.2.0 → MIDI = 12 + 48 = 60
+        assert parsed.notes[0].pitch == 12
+        assert parsed.notes[0].midi == 60
+
+    def test_legacy_format_no_version(self, tmp_path):
+        """Legacy file without #VERSION treats pitch as raw MIDI."""
+        txt = _write_ultrastar(tmp_path, """\
+            #TITLE:Test
+            #ARTIST:Test
+            #BPM:300
+            #GAP:5000
+            : 0 5 60 Hello
+            E
+        """)
+        parsed = parse_ultrastar(txt)
+        assert parsed.version is None
+        # pitch=60 in legacy → MIDI = 60 (no offset)
+        assert parsed.notes[0].pitch == 60
+        assert parsed.notes[0].midi == 60
+
+    def test_v110_format_no_offset(self, tmp_path):
+        """v1.1.0 file still uses raw MIDI (offset only from v1.2.0+)."""
+        txt = _write_ultrastar(tmp_path, """\
+            #VERSION:1.1.0
+            #TITLE:Test
+            #ARTIST:Test
+            #BPM:300
+            #GAP:5000
+            : 0 5 60 Hello
+            E
+        """)
+        parsed = parse_ultrastar(txt)
+        assert parsed.version == "1.1.0"
+        assert parsed.notes[0].midi == 60  # no offset for < 1.2.0
+
+    def test_mixed_format_comparison_gives_zero_diff(self, tmp_path):
+        """Comparing v1.2.0 (pitch=12) vs legacy (pitch=60) yields 0 diff.
+
+        Both represent MIDI note 60 — the tool must normalise before comparing.
+        """
+        gen_txt = _write_ultrastar(tmp_path, """\
+            #VERSION:1.2.0
+            #TITLE:Test
+            #ARTIST:Test
+            #BPM:300
+            #GAP:5000
+            : 0 5 12 Hello
+            E
+        """, name="gen.txt")
+
+        ref_txt = _write_ultrastar(tmp_path, """\
+            #TITLE:Test
+            #ARTIST:Test
+            #BPM:300
+            #GAP:5000
+            : 0 5 60 Hello
+            E
+        """, name="ref.txt")
+
+        result = compare(gen_txt, ref_txt)
+        assert result.pitch_median == 0.0
+        assert result.pitch_exact_pct == 100.0
+
+
+# ── Pitch conversion unit tests ─────────────────────────────────────────────
+
+class TestPitchToMidi:
+    """Unit tests for the _pitch_to_midi helper."""
+
+    def test_v120_adds_48(self):
+        """v1.2.0 format adds +48 offset to convert to MIDI."""
+        assert _pitch_to_midi(0, "1.2.0") == 48
+        assert _pitch_to_midi(12, "1.2.0") == 60
+        assert _pitch_to_midi(-12, "1.2.0") == 36
+
+    def test_legacy_returns_raw(self):
+        """Legacy format (no version) returns pitch as-is."""
+        assert _pitch_to_midi(60, None) == 60
+        assert _pitch_to_midi(48, None) == 48
+
+    def test_v110_returns_raw(self):
+        """v1.1.0 is below the 1.2.0 threshold, so no offset."""
+        assert _pitch_to_midi(60, "1.1.0") == 60
+
+    def test_v200_adds_48(self):
+        """v2.0.0 is >= 1.2.0, so offset applies."""
+        assert _pitch_to_midi(0, "2.0.0") == 48
+
+
+class TestVersionGe:
+    """Unit tests for the _version_ge semantic version comparison helper."""
+
+    def test_equal(self):
+        """Equal versions return True."""
+        assert _version_ge("1.2.0", "1.2.0") is True
+
+    def test_greater(self):
+        """Greater version returns True."""
+        assert _version_ge("2.0.0", "1.2.0") is True
+
+    def test_less(self):
+        """Lesser version returns False."""
+        assert _version_ge("1.1.0", "1.2.0") is False
+
+    def test_invalid_returns_false(self):
+        """Malformed version string returns False gracefully."""
+        assert _version_ge("abc", "1.2.0") is False
+
+
+# ── Beat-to-ms conversion ───────────────────────────────────────────────────
+
+class TestBeatToMs:
+    """UltraStar BPM header represents quarter-notes at 4x the real BPM."""
+
+    def test_zero_beat_returns_gap(self):
+        """Beat 0 returns exactly the GAP value."""
+        assert _beat_to_ms(0, 300.0, 5000.0) == 5000.0
+
+    def test_formula(self):
+        """Verify beat-to-ms formula: gap + (beat * 60000) / (bpm * 4)."""
+        # bpm_header=300, real_bpm=1200
+        # beat=120 → 5000 + (120 * 60000) / 1200 = 5000 + 6000 = 11000
+        assert _beat_to_ms(120, 300.0, 5000.0) == 11000.0
+
+    def test_zero_bpm_returns_gap(self):
+        """Edge case: BPM=0 should not crash, just return GAP."""
+        assert _beat_to_ms(100, 0, 5000.0) == 5000.0
+
+    def test_comma_bpm_parsing(self):
+        """BPM may use comma as decimal separator."""
+        assert _parse_bpm("409,66") == 409.66
+
+    def test_comma_gap_parsing(self):
+        """GAP may use comma as decimal separator."""
+        assert _parse_gap("5000,5") == 5000.5
+
+
+# ── Tilde note grouping ─────────────────────────────────────────────────────
+
+class TestTildeGrouping:
+    """Tests for grouping continuation notes (~) with their parent word."""
+
+    def _make_note(self, word, midi=60, start_ms=0, end_ms=100):
+        """Create a Note instance for testing."""
+        return Note(
+            note_type=":",
+            start_beat=0,
+            duration=5,
+            pitch=midi,
+            midi=midi,
+            word=word,
+            start_ms=start_ms,
+            end_ms=end_ms,
+        )
+
+    def test_tilde_groups_with_parent(self):
+        """Tilde notes are appended to the preceding word group."""
+        notes = [
+            self._make_note("Hel", start_ms=0, end_ms=100),
+            self._make_note("~lo", start_ms=100, end_ms=200),
+            self._make_note("World", start_ms=300, end_ms=400),
+        ]
+        groups = _group_words(notes)
+        assert len(groups) == 2
+        assert groups[0].word == "Hel"
+        assert len(groups[0].notes) == 2
+        assert groups[0].end_ms == 200  # extended by tilde note
+        assert groups[1].word == "World"
+        assert len(groups[1].notes) == 1
+
+    def test_multiple_tildes(self):
+        """Multiple consecutive tildes all attach to the same parent."""
+        notes = [
+            self._make_note("Beau", start_ms=0, end_ms=50),
+            self._make_note("~ti", start_ms=50, end_ms=100),
+            self._make_note("~ful", start_ms=100, end_ms=150),
+        ]
+        groups = _group_words(notes)
+        assert len(groups) == 1
+        assert len(groups[0].notes) == 3
+        assert groups[0].end_ms == 150
+
+    def test_tilde_at_start_becomes_own_group(self):
+        """A tilde as the very first note cannot attach to a parent."""
+        notes = [
+            self._make_note("~orphan", start_ms=0, end_ms=100),
+            self._make_note("Word", start_ms=200, end_ms=300),
+        ]
+        groups = _group_words(notes)
+        # ~orphan becomes its own group since there is no parent
+        assert len(groups) == 2
+
+    def test_primary_midi_is_first_note(self):
+        """WordGroup.midi comes from the first note in the group."""
+        notes = [
+            self._make_note("Test", midi=60, start_ms=0, end_ms=100),
+            self._make_note("~ing", midi=65, start_ms=100, end_ms=200),
+        ]
+        groups = _group_words(notes)
+        assert groups[0].midi == 60  # first note's MIDI, not 65
+
+
+# ── Word alignment ───────────────────────────────────────────────────────────
+
+class TestWordAlignment:
+    """Tests for fuzzy word alignment between generated and reference files."""
+
+    def _make_wg(self, word, midi=60, start_ms=0):
+        """Create a WordGroup instance for testing."""
+        return WordGroup(word=word, midi=midi, start_ms=start_ms)
+
+    def test_exact_match(self):
+        """Identical word sequences yield 1:1 index pairs."""
+        gen = [self._make_wg("Hello"), self._make_wg("World")]
+        ref = [self._make_wg("Hello"), self._make_wg("World")]
+        pairs = align_words(gen, ref)
+        assert pairs == [(0, 0), (1, 1)]
+
+    def test_partial_match_with_extra_words(self):
+        """Shared words are matched even when surrounding words differ."""
+        gen = [self._make_wg("the"), self._make_wg("quick"), self._make_wg("fox")]
+        ref = [self._make_wg("quick"), self._make_wg("brown"), self._make_wg("fox")]
+        pairs = align_words(gen, ref)
+        # "quick" and "fox" should match
+        matched_gen_words = [gen[gi].word for gi, ri in pairs]
+        assert "quick" in matched_gen_words
+        assert "fox" in matched_gen_words
+
+    def test_case_insensitive(self):
+        """Word matching is case-insensitive."""
+        gen = [self._make_wg("HELLO")]
+        ref = [self._make_wg("hello")]
+        pairs = align_words(gen, ref)
+        assert len(pairs) == 1
+
+    def test_punctuation_ignored(self):
+        """Punctuation is stripped before matching."""
+        gen = [self._make_wg("don't")]
+        ref = [self._make_wg("dont")]
+        pairs = align_words(gen, ref)
+        assert len(pairs) == 1
+
+    def test_empty_words_skipped(self):
+        """Empty word strings are excluded from alignment."""
+        gen = [self._make_wg(""), self._make_wg("Hello")]
+        ref = [self._make_wg("Hello"), self._make_wg("")]
+        pairs = align_words(gen, ref)
+        # Only "Hello" should match
+        assert len(pairs) == 1
+
+
+# ── Timing ───────────────────────────────────────────────────────────────────
+
+class TestTiming:
+    """Tests for timing difference calculations."""
+
+    def test_first_word_excluded_from_timing(self, tmp_path):
+        """Timing metrics exclude the first matched word (GAP offset effect)."""
+        gen_txt = _write_ultrastar(tmp_path, """\
+            #TITLE:Test
+            #ARTIST:Test
+            #BPM:300
+            #GAP:0
+            : 0 5 60 First
+            : 100 5 62 Second
+            : 200 5 64 Third
+            E
+        """, name="gen.txt")
+
+        ref_txt = _write_ultrastar(tmp_path, """\
+            #TITLE:Test
+            #ARTIST:Test
+            #BPM:300
+            #GAP:0
+            : 0 5 60 First
+            : 100 5 62 Second
+            : 200 5 64 Third
+            E
+        """, name="ref.txt")
+
+        result = compare(gen_txt, ref_txt)
+        # 3 matched words, but timing_diffs only has 2 (first excluded)
+        assert result.matched_pairs == 3
+        assert len(result.timing_diffs) == 2
+
+    def test_timing_calculation_correct(self, tmp_path):
+        """Verify timing differences are computed from beat→ms conversion."""
+        # BPM=300, real_bpm=1200, ms_per_beat = 60000/1200 = 50ms
+        gen_txt = _write_ultrastar(tmp_path, """\
+            #TITLE:Test
+            #ARTIST:Test
+            #BPM:300
+            #GAP:1000
+            : 0 5 60 Hello
+            : 20 5 60 World
+            E
+        """, name="gen.txt")
+
+        ref_txt = _write_ultrastar(tmp_path, """\
+            #TITLE:Test
+            #ARTIST:Test
+            #BPM:300
+            #GAP:1000
+            : 0 5 60 Hello
+            : 22 5 60 World
+            E
+        """, name="ref.txt")
+
+        result = compare(gen_txt, ref_txt)
+        # "World": gen at beat 20 → 1000 + 20*50 = 2000ms
+        #          ref at beat 22 → 1000 + 22*50 = 2100ms
+        # diff = 2000 - 2100 = -100ms
+        assert len(result.timing_diffs) == 1  # first word excluded
+        assert result.timing_diffs[0] == pytest.approx(-100.0, abs=0.1)
+
+
+# ── Intervals ────────────────────────────────────────────────────────────────
+
+class TestIntervals:
+    """Tests for pitch interval comparison between consecutive matched words."""
+
+    def test_interval_format_independent(self, tmp_path):
+        """Intervals cancel out any constant pitch offset between formats.
+
+        v1.2.0 pitches 12, 17, 19 → MIDI 60, 65, 67
+        Legacy pitches 60, 65, 67 → MIDI 60, 65, 67
+        Intervals: +5, +2 vs +5, +2 → diffs all 0
+        """
+        gen_txt = _write_ultrastar(tmp_path, """\
+            #VERSION:1.2.0
+            #TITLE:Test
+            #ARTIST:Test
+            #BPM:300
+            #GAP:0
+            : 0 5 12 One
+            : 20 5 17 Two
+            : 40 5 19 Three
+            E
+        """, name="gen.txt")
+
+        ref_txt = _write_ultrastar(tmp_path, """\
+            #TITLE:Test
+            #ARTIST:Test
+            #BPM:300
+            #GAP:0
+            : 0 5 60 One
+            : 20 5 65 Two
+            : 40 5 67 Three
+            E
+        """, name="ref.txt")
+
+        result = compare(gen_txt, ref_txt)
+        assert len(result.interval_diffs) == 2
+        assert all(d == 0 for d in result.interval_diffs)
+        assert result.interval_exact_pct == 100.0
+
+    def test_interval_detects_wrong_jump(self, tmp_path):
+        """An incorrect interval is reported."""
+        gen_txt = _write_ultrastar(tmp_path, """\
+            #TITLE:Test
+            #ARTIST:Test
+            #BPM:300
+            #GAP:0
+            : 0 5 60 One
+            : 20 5 67 Two
+            E
+        """, name="gen.txt")
+
+        ref_txt = _write_ultrastar(tmp_path, """\
+            #TITLE:Test
+            #ARTIST:Test
+            #BPM:300
+            #GAP:0
+            : 0 5 60 One
+            : 20 5 65 Two
+            E
+        """, name="ref.txt")
+
+        result = compare(gen_txt, ref_txt)
+        # gen interval = 67 - 60 = 7
+        # ref interval = 65 - 60 = 5
+        # diff = 7 - 5 = 2
+        assert result.interval_diffs == [2]
+
+
+# ── Parsing ──────────────────────────────────────────────────────────────────
+
+class TestParsing:
+    """Tests for UltraStar TXT file parsing."""
+
+    def test_note_types_parsed(self, tmp_path):
+        """All standard note types are parsed correctly."""
+        txt = _write_ultrastar(tmp_path, """\
+            #TITLE:Test
+            #ARTIST:Test
+            #BPM:300
+            #GAP:0
+            : 0 5 60 Normal
+            * 10 5 62 Golden
+            F 20 5 64 Freestyle
+            R 30 5 66 Rap
+            G 40 5 68 RapGolden
+            E
+        """)
+        parsed = parse_ultrastar(txt)
+        types = [n.note_type for n in parsed.notes]
+        assert types == [":", "*", "F", "R", "G"]
+
+    def test_linebreak_counting(self, tmp_path):
+        """Linebreak markers are counted but not treated as notes."""
+        txt = _write_ultrastar(tmp_path, """\
+            #TITLE:Test
+            #ARTIST:Test
+            #BPM:300
+            #GAP:0
+            : 0 5 60 Hello
+            - 10
+            : 20 5 62 World
+            - 30
+            : 40 5 64 End
+            E
+        """)
+        parsed = parse_ultrastar(txt)
+        assert parsed.linebreak_count == 2
+        assert len(parsed.notes) == 3  # linebreaks not counted as notes
+
+    def test_headers_collected(self, tmp_path):
+        """All header tags are stored in the headers dict."""
+        txt = _write_ultrastar(tmp_path, """\
+            #TITLE:My Song
+            #ARTIST:Some Artist
+            #BPM:300
+            #GAP:5000
+            #LANGUAGE:English
+            : 0 5 60 Hello
+            E
+        """)
+        parsed = parse_ultrastar(txt)
+        assert parsed.headers["TITLE"] == "My Song"
+        assert parsed.headers["ARTIST"] == "Some Artist"
+        assert parsed.headers["LANGUAGE"] == "English"
+
+    def test_end_marker_stops_parsing(self, tmp_path):
+        """Lines after 'E' are ignored."""
+        txt = _write_ultrastar(tmp_path, """\
+            #TITLE:Test
+            #ARTIST:Test
+            #BPM:300
+            #GAP:0
+            : 0 5 60 Hello
+            E
+            : 100 5 62 ShouldBeIgnored
+        """)
+        parsed = parse_ultrastar(txt)
+        assert len(parsed.notes) == 1
+
+    def test_comma_bpm_gap(self, tmp_path):
+        """European-style comma decimals are handled."""
+        txt = _write_ultrastar(tmp_path, """\
+            #TITLE:Test
+            #ARTIST:Test
+            #BPM:409,66
+            #GAP:12763,5
+            : 0 5 60 Hello
+            E
+        """)
+        parsed = parse_ultrastar(txt)
+        assert parsed.bpm == pytest.approx(409.66, abs=0.01)
+        assert parsed.gap == pytest.approx(12763.5, abs=0.1)
+
+
+# ── JSON output ──────────────────────────────────────────────────────────────
+
+class TestJsonOutput:
+    """Tests for JSON serialisation of comparison results."""
+
+    def test_json_has_expected_structure(self, tmp_path):
+        """JSON output contains all expected top-level sections."""
+        gen_txt = _write_ultrastar(tmp_path, """\
+            #TITLE:Test
+            #ARTIST:Test
+            #BPM:300
+            #GAP:0
+            : 0 5 60 Hello
+            E
+        """, name="gen.txt")
+
+        ref_txt = _write_ultrastar(tmp_path, """\
+            #TITLE:Test
+            #ARTIST:Test
+            #BPM:300
+            #GAP:0
+            : 0 5 60 Hello
+            E
+        """, name="ref.txt")
+
+        result = compare(gen_txt, ref_txt)
+        data = json.loads(result.to_json())
+
+        assert "pitch" in data
+        assert "intervals" in data
+        assert "timing" in data
+        assert "lyrics" in data
+        assert "structure" in data
+        assert "meta" in data
+
+        # Verify key fields exist
+        assert "median_diff" in data["pitch"]
+        assert "exact_pct" in data["pitch"]
+        assert "within_2st_pct" in data["pitch"]
+        assert "median_ms" in data["timing"]
+        assert "within_100ms_pct" in data["timing"]
+        assert "gen_notes" in data["structure"]
+        assert "ref_notes" in data["structure"]
+        assert "gen_version" in data["meta"]
+        assert "ref_version" in data["meta"]
+
+
+# ── Full comparison integration ──────────────────────────────────────────────
+
+class TestFullComparison:
+    """Integration tests running the full compare() pipeline."""
+
+    def test_identical_files_perfect_score(self, tmp_path):
+        """Comparing identical files should yield perfect metrics."""
+        content = """\
+            #TITLE:Test
+            #ARTIST:Test
+            #BPM:300
+            #GAP:5000
+            : 0 5 60 Hello
+            : 20 5 62 World
+            : 40 5 64 Again
+            - 50
+            : 60 5 66 More
+            E
+        """
+        gen_txt = _write_ultrastar(tmp_path, content, name="gen.txt")
+        ref_txt = _write_ultrastar(tmp_path, content, name="ref.txt")
+
+        result = compare(gen_txt, ref_txt)
+
+        assert result.pitch_exact_pct == 100.0
+        assert result.pitch_median == 0.0
+        assert result.interval_exact_pct == 100.0
+        assert result.timing_within_100 == 100.0
+        assert result.lyrics_precision == 100.0
+        assert result.lyrics_recall == 100.0
+        assert result.matched_pairs == 4
+        assert result.gen_linebreaks == 1
+        assert result.ref_linebreaks == 1
+
+    def test_no_matching_words(self, tmp_path):
+        """No matching words → empty metrics, no crash."""
+        gen_txt = _write_ultrastar(tmp_path, """\
+            #TITLE:Test
+            #ARTIST:Test
+            #BPM:300
+            #GAP:0
+            : 0 5 60 Alpha
+            E
+        """, name="gen.txt")
+
+        ref_txt = _write_ultrastar(tmp_path, """\
+            #TITLE:Test
+            #ARTIST:Test
+            #BPM:300
+            #GAP:0
+            : 0 5 60 Beta
+            E
+        """, name="ref.txt")
+
+        result = compare(gen_txt, ref_txt)
+        assert result.matched_pairs == 0
+        assert result.pitch_exact_pct == 0.0
+        assert result.lyrics_recall == 0.0
+
+    def test_summary_output_not_empty(self, tmp_path):
+        """Human-readable summary produces non-empty output."""
+        content = """\
+            #TITLE:Test
+            #ARTIST:Test
+            #BPM:300
+            #GAP:0
+            : 0 5 60 Hello
+            E
+        """
+        gen_txt = _write_ultrastar(tmp_path, content, name="gen.txt")
+        ref_txt = _write_ultrastar(tmp_path, content, name="ref.txt")
+
+        result = compare(gen_txt, ref_txt)
+        summary = result.to_summary()
+        assert "UltraStar Comparison Report" in summary
+        assert "Pitch" in summary
+        assert "Timing" in summary
+
+
+# ── Edge cases ───────────────────────────────────────────────────────────────
+
+class TestEdgeCases:
+    """Edge cases and utility function tests."""
+
+    def test_normalise_word(self):
+        """Word normalisation strips punctuation and lowercases."""
+        assert _normalise_word("Don't") == "dont"
+        assert _normalise_word("HELLO!") == "hello"
+        assert _normalise_word("  spaces  ") == "spaces"
+        assert _normalise_word("café") == "cafe"  # accented → decomposed
+
+    def test_pct_zero_total(self):
+        """Percentage with zero denominator returns 0.0 instead of crashing."""
+        assert _pct(5, 0) == 0.0
+        assert _pct(0, 0) == 0.0
+
+    def test_pct_normal(self):
+        """Normal percentage calculation works correctly."""
+        assert _pct(1, 4) == 25.0
+        assert _pct(3, 3) == 100.0
+
+    def test_empty_file(self, tmp_path):
+        """An empty file should parse without crashing."""
+        txt = _write_ultrastar(tmp_path, "")
+        parsed = parse_ultrastar(txt)
+        assert parsed.notes == []
+        assert parsed.word_groups == []
+        assert parsed.bpm == 0.0

--- a/src/Settings.py
+++ b/src/Settings.py
@@ -27,6 +27,7 @@ class Settings:
     interactive_mode = False
     user_ffmpeg_path = ""
     quantize_to_key = True  # Quantize notes to the detected key of the song
+    bpm_override = None  # Manual BPM override (float), skips auto-detection when set
 
     # Process data Paths
     input_file_path = ""

--- a/src/Settings.py
+++ b/src/Settings.py
@@ -58,6 +58,11 @@ class Settings:
     # yt-dlp
     cookiefile = None
 
+    # Denoise
+    denoise_noise_reduction = 20  # Noise reduction in dB (0.01-97, default: 20). Previous default was 70 which destroyed vocal nuances needed by Whisper.
+    denoise_noise_floor = -80  # Noise floor in dB (-80 to -20, default: -80)
+    denoise_track_noise = True  # Enable adaptive noise floor tracking
+
     # UltraSinger Evaluation Configuration
     test_songs_input_folder = None
     cache_override_path = None #"C:\\UltraSinger\\test_output"

--- a/src/Settings.py
+++ b/src/Settings.py
@@ -57,7 +57,6 @@ class Settings:
 
     # yt-dlp
     cookiefile = None
-    cookies_from_browser = None  # Browser name for yt-dlp to read cookies from (e.g. "chrome", "firefox", "edge")
 
     # Denoise
     denoise_noise_reduction = 20  # Noise reduction in dB (0.01-97, default: 20). Previous default was 70 which destroyed vocal nuances needed by Whisper.

--- a/src/Settings.py
+++ b/src/Settings.py
@@ -57,6 +57,7 @@ class Settings:
 
     # yt-dlp
     cookiefile = None
+    cookies_from_browser = None  # Browser name for yt-dlp to read cookies from (e.g. "chrome", "firefox", "edge")
 
     # Denoise
     denoise_noise_reduction = 20  # Noise reduction in dB (0.01-97, default: 20). Previous default was 70 which destroyed vocal nuances needed by Whisper.

--- a/src/Settings.py
+++ b/src/Settings.py
@@ -28,6 +28,7 @@ class Settings:
     user_ffmpeg_path = ""
     quantize_to_key = True  # Quantize notes to the detected key of the song
     bpm_override = None  # Manual BPM override (float), skips auto-detection when set
+    octave_shift = None  # Manual octave shift (int), shifts all notes by N octaves after detection
 
     # Process data Paths
     input_file_path = ""

--- a/src/UltraSinger.py
+++ b/src/UltraSinger.py
@@ -637,7 +637,7 @@ def transcribe_audio(cache_folder_path: str, audio_path: str) -> TranscriptionRe
     transcription_result = None
     whisper_align_model_string = None
     if settings.transcriber == "whisper":
-        if not settings.whisper_align_model is None:
+        if settings.whisper_align_model is not None:
             whisper_align_model_string = settings.whisper_align_model.replace("/", "_")
         whisper_device = "cpu" if settings.force_whisper_cpu else settings.pytorch_device
         transcription_config = f"{settings.transcriber}_{settings.whisper_model.value}_{whisper_device}_{whisper_align_model_string}_{settings.whisper_batch_size}_{settings.whisper_compute_type}_{settings.language}_unmuted"

--- a/src/UltraSinger.py
+++ b/src/UltraSinger.py
@@ -582,10 +582,6 @@ def CreateProcessAudio(process_data) -> tuple[str, str]:
     Muting zeroes silent sections which helps pitch detection focus on singing,
     but destroys onset information that WhisperX's forced alignment needs.
     """
-    # Set processing audio to cache file
-    process_data.process_data_paths.processing_audio_path = os.path.join(
-        process_data.process_data_paths.cache_folder_path, process_data.basename + ".wav"
-    )
     os_helper.create_folder(process_data.process_data_paths.cache_folder_path)
 
     # Separate vocal from audio
@@ -636,7 +632,7 @@ def CreateProcessAudio(process_data) -> tuple[str, str]:
     return whisper_audio_path, pitch_audio_path
 
 
-def transcribe_audio(cache_folder_path: str, processing_audio_path: str) -> TranscriptionResult:
+def transcribe_audio(cache_folder_path: str, audio_path: str) -> TranscriptionResult:
     """Transcribe audio with AI"""
     transcription_result = None
     whisper_align_model_string = None
@@ -644,12 +640,12 @@ def transcribe_audio(cache_folder_path: str, processing_audio_path: str) -> Tran
         if not settings.whisper_align_model is None:
             whisper_align_model_string = settings.whisper_align_model.replace("/", "_")
         whisper_device = "cpu" if settings.force_whisper_cpu else settings.pytorch_device
-        transcription_config = f"{settings.transcriber}_{settings.whisper_model.value}_{whisper_device}_{whisper_align_model_string}_{settings.whisper_batch_size}_{settings.whisper_compute_type}_{settings.language}"
+        transcription_config = f"{settings.transcriber}_{settings.whisper_model.value}_{whisper_device}_{whisper_align_model_string}_{settings.whisper_batch_size}_{settings.whisper_compute_type}_{settings.language}_unmuted"
         transcription_path = os.path.join(cache_folder_path, f"{transcription_config}.json")
         cached_transcription_available = check_file_exists(transcription_path)
         if settings.skip_cache_transcription or not cached_transcription_available:
             transcription_result = transcribe_with_whisper(
-                processing_audio_path,
+                audio_path,
                 settings.whisper_model,
                 whisper_device,
                 settings.whisper_align_model,

--- a/src/UltraSinger.py
+++ b/src/UltraSinger.py
@@ -862,10 +862,6 @@ def init_settings(argv: list[str]) -> Settings:
             settings.keep_numbers = True
         elif opt in ("--language"):
             settings.language = arg
-        elif opt in ("--crepe"):
-            settings.crepe_model_capacity = arg
-        elif opt in ("--crepe_step_size"):
-            settings.crepe_step_size = int(arg)
         elif opt in ("--plot"):
             settings.create_plot = True
         elif opt in ("--midi"):
@@ -885,8 +881,6 @@ def init_settings(argv: list[str]) -> Settings:
             os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
         elif opt in ("--force_whisper_cpu"):
             settings.force_whisper_cpu = True
-        elif opt in ("--force_crepe_cpu"):
-            settings.force_crepe_cpu = True
         elif opt in ("--format_version"):
             if arg == FormatVersion.V0_3_0.value:
                 settings.format_version = FormatVersion.V0_3_0
@@ -952,8 +946,6 @@ def arg_options():
         "ofile=",
         "bpm=",
         "octave=",
-        "crepe=",
-        "crepe_step_size=",
         "demucs=",
         "whisper=",
         "whisper_align_model=",
@@ -969,7 +961,6 @@ def arg_options():
         "ignore_audio",
         "force_cpu",
         "force_whisper_cpu",
-        "force_crepe_cpu",
         "format_version=",
         "keep_cache",
         "musescore_path=",

--- a/src/UltraSinger.py
+++ b/src/UltraSinger.py
@@ -487,7 +487,7 @@ def InitProcessData():
             settings.output_folder_path,
             process_data.process_data_paths.audio_output_file_path,
             process_data.media_info
-        ) = download_from_youtube(settings.input_file_path, settings.output_folder_path, settings.cookiefile)
+        ) = download_from_youtube(settings.input_file_path, settings.output_folder_path, settings.cookiefile, settings.cookies_from_browser)
     else:
         # Audio/Video File
         print(f"{ULTRASINGER_HEAD} {gold_highlighted('Full Automatic Mode')}")
@@ -876,6 +876,8 @@ def init_settings(argv: list[str]) -> Settings:
                 sys.exit()
         elif opt in ("--cookiefile"):
             settings.cookiefile = arg
+        elif opt in ("--cookies_from_browser"):
+            settings.cookies_from_browser = arg
         elif opt in ("--interactive"):
             settings.interactive_mode = True
         elif opt in ("--quantize_to_key"):
@@ -937,6 +939,7 @@ def arg_options():
         "quantize_to_key",
         "interactive",
         "cookiefile=",
+        "cookies_from_browser=",
         "ffmpeg=",
         "denoise_nr=",
         "denoise_nf=",

--- a/src/UltraSinger.py
+++ b/src/UltraSinger.py
@@ -38,6 +38,7 @@ from modules.console_colors import (
 from modules.Midi.midi_creator import (
     create_midi_segments_from_transcribed_data,
     create_repitched_midi_segments_from_ultrastar_txt,
+    correct_octave_outliers,
     create_midi_file,
 )
 from modules.Midi.MidiSegment import MidiSegment
@@ -223,6 +224,9 @@ def run() -> tuple[str, Score, Score]:
     else:
         process_data.midi_segments = create_repitched_midi_segments_from_ultrastar_txt(process_data.pitched_data,
                                                                                        process_data.parsed_file)
+
+    # Correct octave outliers
+    process_data.midi_segments = correct_octave_outliers(process_data.midi_segments)
 
     # Merge syllable segments
     if not settings.ignore_audio:

--- a/src/UltraSinger.py
+++ b/src/UltraSinger.py
@@ -169,15 +169,19 @@ def run() -> tuple[str, Score, Score]:
         else settings.cache_override_path
     )
 
-    # Create process audio
-    process_data.process_data_paths.processing_audio_path = CreateProcessAudio(process_data)
+    # Create process audio — two separate paths:
+    # whisper_audio_path: un-muted mono for Whisper, BPM, key detection
+    # processing_audio_path: muted for pitch detection (SwiftF0)
+    whisper_audio_path, pitch_audio_path = CreateProcessAudio(process_data)
+    process_data.process_data_paths.whisper_audio_path = whisper_audio_path
+    process_data.process_data_paths.processing_audio_path = pitch_audio_path
 
-    # Get BPM from wav file
+    # Get BPM from wav file (use un-muted audio — muting can distort librosa.tempo)
     if not settings.input_file_is_ultrastar_txt:
-        process_data.media_info.bpm = get_bpm_from_file(process_data.process_data_paths.processing_audio_path)
+        process_data.media_info.bpm = get_bpm_from_file(process_data.process_data_paths.whisper_audio_path)
 
-    # Detect key
-    detected_key, detected_mode = detect_key_from_audio(process_data.process_data_paths.processing_audio_path)
+    # Detect key (use un-muted audio)
+    detected_key, detected_mode = detect_key_from_audio(process_data.process_data_paths.whisper_audio_path)
     if process_data.media_info.music_key is None:
         process_data.media_info.music_key = f"{detected_key} {detected_mode}"
 
@@ -498,8 +502,10 @@ def InitProcessData():
 
 
 def TranscribeAudio(process_data):
+    # Use un-muted audio for Whisper — muted audio causes WhisperX's wav2vec2
+    # forced alignment to lose sync at zero→audio transitions
     transcription_result = transcribe_audio(process_data.process_data_paths.cache_folder_path,
-                                            process_data.process_data_paths.processing_audio_path)
+                                            process_data.process_data_paths.whisper_audio_path)
 
     if process_data.media_info.language is None:
         process_data.media_info.language = transcription_result.detected_language
@@ -515,8 +521,10 @@ def TranscribeAudio(process_data):
         if hyphen_words is not None:
             process_data.transcribed_data = add_hyphen_to_data(process_data.transcribed_data, hyphen_words)
 
+    # Use un-muted audio for silence detection — running on muted audio
+    # detects more silence than actually exists in the original
     process_data.transcribed_data = remove_silence_from_transcription_data(
-        process_data.process_data_paths.processing_audio_path, process_data.transcribed_data
+        process_data.process_data_paths.whisper_audio_path, process_data.transcribed_data
     )
 
 
@@ -563,7 +571,17 @@ def CreateUltraStarTxt(process_data: ProcessData):
     return accurate_score, simple_score, ultrastar_file_output
 
 
-def CreateProcessAudio(process_data) -> str:
+def CreateProcessAudio(process_data) -> tuple[str, str]:
+    """Create processed audio files.
+
+    Returns two paths:
+    - whisper_audio_path: denoised mono audio (no muting) for Whisper transcription,
+      BPM detection, key detection, and silence-based transcription cleanup.
+    - pitch_audio_path: muted audio for pitch detection (SwiftF0).
+
+    Muting zeroes silent sections which helps pitch detection focus on singing,
+    but destroys onset information that WhisperX's forced alignment needs.
+    """
     # Set processing audio to cache file
     process_data.process_data_paths.processing_audio_path = os.path.join(
         process_data.process_data_paths.cache_folder_path, process_data.basename + ".wav"
@@ -601,20 +619,21 @@ def CreateProcessAudio(process_data) -> str:
                         noise_floor=settings.denoise_noise_floor,
                         track_noise=settings.denoise_track_noise)
 
-    # Convert to mono audio
+    # Convert to mono audio — this is the Whisper path (no muting)
     mono_output_path = os.path.join(
         process_data.process_data_paths.cache_folder_path, process_data.basename + "_mono.wav"
     )
     convert_audio_to_mono_wav(denoised_output_path, mono_output_path)
+    whisper_audio_path = mono_output_path
 
-    # Mute silence sections
+    # Mute silence sections — this is the pitch detection path
     mute_output_path = os.path.join(
         process_data.process_data_paths.cache_folder_path, process_data.basename + "_mute.wav"
     )
     mute_no_singing_parts(mono_output_path, mute_output_path)
+    pitch_audio_path = mute_output_path
 
-    # Define the audio file to process
-    return mute_output_path
+    return whisper_audio_path, pitch_audio_path
 
 
 def transcribe_audio(cache_folder_path: str, processing_audio_path: str) -> TranscriptionResult:

--- a/src/UltraSinger.py
+++ b/src/UltraSinger.py
@@ -589,10 +589,16 @@ def CreateProcessAudio(process_data) -> str:
         input_path = process_data.process_data_paths.audio_output_file_path
 
     # Denoise vocal audio
+    # Include denoise parameters in cache filename so changed settings invalidate the cache
+    denoise_config = f"nr{settings.denoise_noise_reduction}_nf{settings.denoise_noise_floor}_tn{int(settings.denoise_track_noise)}"
     denoised_output_path = os.path.join(
-        process_data.process_data_paths.cache_folder_path, process_data.basename + "_denoised.wav"
+        process_data.process_data_paths.cache_folder_path, process_data.basename + f"_denoised_{denoise_config}.wav"
     )
-    denoise_vocal_audio(input_path, denoised_output_path, settings.skip_cache_denoise_vocal_audio)
+    denoise_vocal_audio(input_path, denoised_output_path,
+                        skip_cache=settings.skip_cache_denoise_vocal_audio,
+                        noise_reduction=settings.denoise_noise_reduction,
+                        noise_floor=settings.denoise_noise_floor,
+                        track_noise=settings.denoise_track_noise)
 
     # Convert to mono audio
     mono_output_path = os.path.join(
@@ -855,6 +861,12 @@ def init_settings(argv: list[str]) -> Settings:
             settings.quantize_to_key = arg
         elif opt in ("--ffmpeg"):
             settings.user_ffmpeg_path = arg
+        elif opt in ("--denoise_nr"):
+            settings.denoise_noise_reduction = float(arg)
+        elif opt in ("--denoise_nf"):
+            settings.denoise_noise_floor = float(arg)
+        elif opt in ("--disable_denoise_track_noise"):
+            settings.denoise_track_noise = False
     if settings.output_folder_path == "":
         if settings.input_file_path.startswith("https:"):
             dirname = os.getcwd()
@@ -896,7 +908,10 @@ def arg_options():
         "quantize_to_key",
         "interactive",
         "cookiefile=",
-        "ffmpeg="
+        "ffmpeg=",
+        "denoise_nr=",
+        "denoise_nf=",
+        "disable_denoise_track_noise",
     ]
     return long, short
 

--- a/src/UltraSinger.py
+++ b/src/UltraSinger.py
@@ -590,7 +590,7 @@ def CreateProcessAudio(process_data) -> str:
 
     # Denoise vocal audio
     # Include denoise parameters in cache filename so changed settings invalidate the cache
-    denoise_config = f"nr{settings.denoise_noise_reduction}_nf{settings.denoise_noise_floor}_tn{int(settings.denoise_track_noise)}"
+    denoise_config = f"nr{float(settings.denoise_noise_reduction):.1f}_nf{float(settings.denoise_noise_floor):.1f}_tn{int(settings.denoise_track_noise)}"
     denoised_output_path = os.path.join(
         process_data.process_data_paths.cache_folder_path, process_data.basename + f"_denoised_{denoise_config}.wav"
     )
@@ -862,9 +862,17 @@ def init_settings(argv: list[str]) -> Settings:
         elif opt in ("--ffmpeg"):
             settings.user_ffmpeg_path = arg
         elif opt in ("--denoise_nr"):
-            settings.denoise_noise_reduction = float(arg)
+            val = float(arg)
+            if not (0.01 <= val <= 97):
+                print(f"Error: --denoise_nr must be between 0.01 and 97, got {val}")
+                sys.exit(1)
+            settings.denoise_noise_reduction = val
         elif opt in ("--denoise_nf"):
-            settings.denoise_noise_floor = float(arg)
+            val = float(arg)
+            if not (-80 <= val <= -20):
+                print(f"Error: --denoise_nf must be between -80 and -20, got {val}")
+                sys.exit(1)
+            settings.denoise_noise_floor = val
         elif opt in ("--disable_denoise_track_noise"):
             settings.denoise_track_noise = False
     if settings.output_folder_path == "":

--- a/src/UltraSinger.py
+++ b/src/UltraSinger.py
@@ -38,6 +38,7 @@ from modules.console_colors import (
 from modules.Midi.midi_creator import (
     create_midi_segments_from_transcribed_data,
     create_repitched_midi_segments_from_ultrastar_txt,
+    correct_global_octave,
     correct_octave_outliers,
     create_midi_file,
 )
@@ -225,7 +226,10 @@ def run() -> tuple[str, Score, Score]:
         process_data.midi_segments = create_repitched_midi_segments_from_ultrastar_txt(process_data.pitched_data,
                                                                                        process_data.parsed_file)
 
-    # Correct octave outliers
+    # Correct global octave shift (e.g. sub-harmonic detection)
+    process_data.midi_segments = correct_global_octave(process_data.midi_segments)
+
+    # Correct local octave outliers
     process_data.midi_segments = correct_octave_outliers(process_data.midi_segments)
 
     # Merge syllable segments

--- a/src/UltraSinger.py
+++ b/src/UltraSinger.py
@@ -487,7 +487,7 @@ def InitProcessData():
             settings.output_folder_path,
             process_data.process_data_paths.audio_output_file_path,
             process_data.media_info
-        ) = download_from_youtube(settings.input_file_path, settings.output_folder_path, settings.cookiefile, settings.cookies_from_browser)
+        ) = download_from_youtube(settings.input_file_path, settings.output_folder_path, settings.cookiefile)
     else:
         # Audio/Video File
         print(f"{ULTRASINGER_HEAD} {gold_highlighted('Full Automatic Mode')}")
@@ -876,8 +876,6 @@ def init_settings(argv: list[str]) -> Settings:
                 sys.exit()
         elif opt in ("--cookiefile"):
             settings.cookiefile = arg
-        elif opt in ("--cookies_from_browser"):
-            settings.cookies_from_browser = arg
         elif opt in ("--interactive"):
             settings.interactive_mode = True
         elif opt in ("--quantize_to_key"):
@@ -939,7 +937,6 @@ def arg_options():
         "quantize_to_key",
         "interactive",
         "cookiefile=",
-        "cookies_from_browser=",
         "ffmpeg=",
         "denoise_nr=",
         "denoise_nf=",

--- a/src/UltraSinger.py
+++ b/src/UltraSinger.py
@@ -38,6 +38,7 @@ from modules.console_colors import (
 from modules.Midi.midi_creator import (
     create_midi_segments_from_transcribed_data,
     create_repitched_midi_segments_from_ultrastar_txt,
+    apply_octave_shift,
     correct_global_octave,
     correct_octave_outliers,
     create_midi_file,
@@ -164,6 +165,8 @@ def run() -> tuple[str, Score, Score]:
         print(f"{ULTRASINGER_HEAD} {bright_green_highlighted('Option:')} {cyan_highlighted('Notes will be quantized to the detected musical key')}")
     if settings.bpm_override is not None:
         print(f"{ULTRASINGER_HEAD} {bright_green_highlighted('Option:')} {cyan_highlighted(f'BPM override: {settings.bpm_override}')}")
+    if settings.octave_shift is not None:
+        print(f"{ULTRASINGER_HEAD} {bright_green_highlighted('Option:')} {cyan_highlighted(f'Octave shift: {settings.octave_shift:+d}')}")
 
     process_data = InitProcessData()
 
@@ -231,6 +234,10 @@ def run() -> tuple[str, Score, Score]:
 
     # Correct local octave outliers
     process_data.midi_segments = correct_octave_outliers(process_data.midi_segments)
+
+    # Apply manual octave shift (after automatic correction, so user gets final say)
+    if settings.octave_shift is not None:
+        process_data.midi_segments = apply_octave_shift(process_data.midi_segments, settings.octave_shift)
 
     # Merge syllable segments
     if not settings.ignore_audio:
@@ -829,6 +836,13 @@ def init_settings(argv: list[str]) -> Settings:
                 print(f"{ULTRASINGER_HEAD} {red_highlighted('Error:')} --bpm must be a positive number, got {val}")
                 sys.exit(1)
             settings.bpm_override = val
+        elif opt == "--octave":
+            try:
+                val = int(arg)
+            except ValueError:
+                print(f"{ULTRASINGER_HEAD} {red_highlighted('Error:')} --octave must be an integer, got {arg}")
+                sys.exit(1)
+            settings.octave_shift = val
         elif opt in ("--whisper"):
             settings.transcriber = "whisper"
 
@@ -937,6 +951,7 @@ def arg_options():
         "ifile=",
         "ofile=",
         "bpm=",
+        "octave=",
         "crepe=",
         "crepe_step_size=",
         "demucs=",

--- a/src/UltraSinger.py
+++ b/src/UltraSinger.py
@@ -160,6 +160,8 @@ def run() -> tuple[str, Score, Score]:
         print(f"{ULTRASINGER_HEAD} {bright_green_highlighted('Option:')} {cyan_highlighted('Hyphenation will not be applied')}")
     if settings.quantize_to_key:
         print(f"{ULTRASINGER_HEAD} {bright_green_highlighted('Option:')} {cyan_highlighted('Notes will be quantized to the detected musical key')}")
+    if settings.bpm_override is not None:
+        print(f"{ULTRASINGER_HEAD} {bright_green_highlighted('Option:')} {cyan_highlighted(f'BPM override: {settings.bpm_override}')}")
 
     process_data = InitProcessData()
 
@@ -176,8 +178,12 @@ def run() -> tuple[str, Score, Score]:
     process_data.process_data_paths.whisper_audio_path = whisper_audio_path
     process_data.process_data_paths.processing_audio_path = pitch_audio_path
 
-    # Get BPM from wav file (use un-muted audio — muting can distort librosa.tempo)
-    if not settings.input_file_is_ultrastar_txt:
+    # Get BPM — manual override takes precedence over auto-detection and .txt BPM
+    if settings.bpm_override is not None:
+        process_data.media_info.bpm = settings.bpm_override
+        print(f"{ULTRASINGER_HEAD} Using manual BPM: {blue_highlighted(str(settings.bpm_override))}")
+    elif not settings.input_file_is_ultrastar_txt:
+        # Auto-detect from wav file (use un-muted audio — muting can distort librosa.tempo)
         process_data.media_info.bpm = get_bpm_from_file(process_data.process_data_paths.whisper_audio_path)
 
     # Detect key (use un-muted audio)
@@ -805,6 +811,16 @@ def init_settings(argv: list[str]) -> Settings:
             settings.input_file_path = arg
         elif opt in ("-o", "--ofile"):
             settings.output_folder_path = arg
+        elif opt == "--bpm":
+            try:
+                val = float(arg)
+            except ValueError:
+                print(f"{ULTRASINGER_HEAD} {red_highlighted('Error:')} --bpm must be a positive number, got {arg}")
+                sys.exit(1)
+            if val <= 0:
+                print(f"{ULTRASINGER_HEAD} {red_highlighted('Error:')} --bpm must be a positive number, got {val}")
+                sys.exit(1)
+            settings.bpm_override = val
         elif opt in ("--whisper"):
             settings.transcriber = "whisper"
 
@@ -912,6 +928,7 @@ def arg_options():
     long = [
         "ifile=",
         "ofile=",
+        "bpm=",
         "crepe=",
         "crepe_step_size=",
         "demucs=",

--- a/src/UltraSinger.py
+++ b/src/UltraSinger.py
@@ -916,8 +916,8 @@ def init_settings(argv: list[str]) -> Settings:
             settings.cookiefile = arg
         elif opt in ("--interactive"):
             settings.interactive_mode = True
-        elif opt in ("--quantize_to_key"):
-            settings.quantize_to_key = arg
+        elif opt in ("--disable_quantization"):
+            settings.quantize_to_key = False
         elif opt in ("--ffmpeg"):
             settings.user_ffmpeg_path = arg
         elif opt in ("--denoise_nr"):
@@ -974,7 +974,7 @@ def arg_options():
         "keep_cache",
         "musescore_path=",
         "keep_numbers",
-        "quantize_to_key",
+        "disable_quantization",
         "interactive",
         "cookiefile=",
         "ffmpeg=",

--- a/src/UltraSinger.py
+++ b/src/UltraSinger.py
@@ -74,6 +74,7 @@ from modules.ffmpeg_helper import (
     get_ffmpeg_and_ffprobe_paths,
     is_video_file,
     separate_audio_video,
+    convert_to_ultrastar_format,
 )
 
 from Settings import Settings
@@ -685,6 +686,11 @@ def infos_from_audio_video_input_file() -> tuple[str, str, str, MediaInfo]:
             os.path.join(song_folder_output_path, basename_with_ext),
         )
         ultrastar_audio_input_path = os.path.join(song_folder_output_path, basename_with_ext)
+
+        # Convert to UltraStar-compatible format if needed
+        ultrastar_audio_input_path, audio_ext = convert_to_ultrastar_format(
+            ultrastar_audio_input_path, basename_without_ext, song_folder_output_path, audio_ext
+        )
 
     # Todo: Read ID3 tags
     if song_info.cover_image_data is not None:

--- a/src/modules/Audio/bpm.py
+++ b/src/modules/Audio/bpm.py
@@ -7,49 +7,94 @@ import soundfile as sf
 from modules.console_colors import ULTRASINGER_HEAD, blue_highlighted
 
 
-def _pick_best_tempo(primary_bpm: float) -> float:
-    """Apply half/double-tempo correction to a detected BPM value.
+# Candidate ratios ordered by musical simplicity.
+# Simpler ratios (identity, half, double) are listed first so that
+# they win ties when two candidates are equally close to the target.
+_TEMPO_RATIOS: list[float] = [
+    1.0,    # identity
+    0.5,    # half-tempo
+    2.0,    # double-tempo
+    1 / 3,  # third-tempo  (e.g. 3/4 waltz detected as compound)
+    3.0,    # triple-tempo
+    0.25,   # quarter-tempo
+    4.0,    # quadruple-tempo
+    2 / 3,  # two-thirds  (e.g. compound metre confusion)
+    1.5,    # dotted-half  (shuffle / swing feel)
+    0.75,   # three-quarters
+]
 
-    Tempo detectors sometimes report double or half the actual tempo.
-    This function generates half and double variants and picks the one
-    in the typical song range (60-200 BPM) that is closest to 120 BPM
-    (a common pop/rock tempo).
+
+def _pick_best_tempo(
+    primary_bpm: float,
+    low: float = 60.0,
+    high: float = 200.0,
+    target: float = 120.0,
+) -> float:
+    """Apply tempo-ratio correction to a detected BPM value.
+
+    Tempo detectors sometimes report a multiple or fraction of the
+    actual tempo.  This function generates candidates by multiplying
+    the detected value with a set of common musical ratios (half,
+    double, third, quarter, etc.) and picks the candidate in the
+    expected range that is closest to *target* BPM.
+
+    If the detected tempo already lies inside ``[low, high]`` it is
+    returned unchanged -- ratio correction only applies to values
+    outside the expected range.  This prevents legitimate fast or slow
+    tempos (e.g. 180 BPM punk rock) from being rescaled.
+
+    When two candidates are equally close to *target*, the one derived
+    from the simpler ratio wins (identity > half/double > third, ...).
 
     Args:
         primary_bpm: The primary tempo estimate from librosa.
+        low: Lower bound of the acceptable BPM range (inclusive).
+        high: Upper bound of the acceptable BPM range (inclusive).
+        target: Preferred tempo centre -- candidates closest to this
+            value are selected.  120 BPM is a common pop/rock tempo.
 
     Returns:
         The corrected tempo in BPM.
     """
     if primary_bpm <= 0:
-        return 120.0  # Fallback
+        return target  # Fallback
 
-    # Generate half/double candidates
-    candidates = [primary_bpm, primary_bpm / 2, primary_bpm * 2]
+    # Already in range -- trust the detector and return as-is.
+    # Ratio correction should only kick in for out-of-range values;
+    # otherwise legitimate fast/slow songs get their tempo rescaled
+    # which breaks all downstream beat-length calculations.
+    if low <= primary_bpm <= high:
+        return primary_bpm
 
-    # Prefer candidates in the typical song range (60-200 BPM)
-    in_range = [c for c in candidates if 60 <= c <= 200]
+    # Generate candidates from all ratios, preserving ratio order
+    candidates = [primary_bpm * r for r in _TEMPO_RATIOS]
+
+    # Prefer candidates in the typical song range
+    in_range = [c for c in candidates if low <= c <= high]
 
     if in_range:
-        # Pick the one closest to 120 BPM (common pop/rock tempo)
-        return min(in_range, key=lambda x: abs(x - 120))
+        # Pick the one closest to target BPM.
+        # Because _TEMPO_RATIOS is ordered by simplicity and min()
+        # is stable (returns the first minimum), simpler ratios win
+        # ties automatically.
+        return min(in_range, key=lambda x: abs(x - target))
 
-    # Nothing in range — use the primary as-is
+    # Nothing in range -- use the primary as-is
     return primary_bpm
 
 
 def get_bpm_from_data(data, sampling_rate):
     """Get real BPM from audio data.
 
-    Uses librosa's default tempo estimation and applies half/double-tempo
+    Uses librosa's default tempo estimation and applies tempo-ratio
     correction to avoid common detection errors where the tempo is
-    reported as 2x or 0.5x the actual value.
+    reported as a multiple or fraction of the actual value.
     """
     onset_env = librosa.onset.onset_strength(y=data, sr=sampling_rate)
     wav_tempo = librosa.feature.tempo(onset_envelope=onset_env, sr=sampling_rate)
     primary_bpm = float(wav_tempo[0])
 
-    # Apply half/double-tempo correction
+    # Apply tempo-ratio correction
     best_bpm = _pick_best_tempo(primary_bpm)
 
     print(

--- a/src/modules/Audio/bpm.py
+++ b/src/modules/Audio/bpm.py
@@ -1,20 +1,65 @@
+"""BPM detection module"""
+
+import numpy as np
 import librosa
 import soundfile as sf
 
 from modules.console_colors import ULTRASINGER_HEAD, blue_highlighted
 
 
+def _pick_best_tempo(primary_bpm: float) -> float:
+    """Apply half/double-tempo correction to a detected BPM value.
+
+    Tempo detectors sometimes report double or half the actual tempo.
+    This function generates half and double variants and picks the one
+    in the typical song range (60-200 BPM) that is closest to 120 BPM
+    (a common pop/rock tempo).
+
+    Args:
+        primary_bpm: The primary tempo estimate from librosa.
+
+    Returns:
+        The corrected tempo in BPM.
+    """
+    if primary_bpm <= 0:
+        return 120.0  # Fallback
+
+    # Generate half/double candidates
+    candidates = [primary_bpm, primary_bpm / 2, primary_bpm * 2]
+
+    # Prefer candidates in the typical song range (60-200 BPM)
+    in_range = [c for c in candidates if 60 <= c <= 200]
+
+    if in_range:
+        # Pick the one closest to 120 BPM (common pop/rock tempo)
+        return min(in_range, key=lambda x: abs(x - 120))
+
+    # Nothing in range — use the primary as-is
+    return primary_bpm
+
+
 def get_bpm_from_data(data, sampling_rate):
-    """Get real bpm from audio data"""
+    """Get real BPM from audio data.
+
+    Uses librosa's default tempo estimation and applies half/double-tempo
+    correction to avoid common detection errors where the tempo is
+    reported as 2x or 0.5x the actual value.
+    """
     onset_env = librosa.onset.onset_strength(y=data, sr=sampling_rate)
     wav_tempo = librosa.feature.tempo(onset_envelope=onset_env, sr=sampling_rate)
+    primary_bpm = float(wav_tempo[0])
 
-    print(f"{ULTRASINGER_HEAD} BPM is {blue_highlighted(str(round(wav_tempo[0], 2)))}")
-    return wav_tempo[0]
+    # Apply half/double-tempo correction
+    best_bpm = _pick_best_tempo(primary_bpm)
+
+    print(
+        f"{ULTRASINGER_HEAD} BPM is {blue_highlighted(str(round(best_bpm, 2)))}"
+    )
+    return best_bpm
 
 
 def get_bpm_from_file(wav_file: str) -> float:
-    """Get real bpm from audio file"""
+    """Get real BPM from audio file."""
     data, sampling_rate = sf.read(wav_file, dtype='float32')
     # Transpose if stereo to match librosa's expected format
     if len(data.shape) > 1:

--- a/src/modules/Audio/bpm.py
+++ b/src/modules/Audio/bpm.py
@@ -26,9 +26,9 @@ _TEMPO_RATIOS: list[float] = [
 
 def _pick_best_tempo(
     primary_bpm: float,
-    low: float = 60.0,
-    high: float = 200.0,
-    target: float = 120.0,
+    low: float = 50.0,
+    high: float = 500.0,
+    target: float | None = None,
 ) -> float:
     """Apply tempo-ratio correction to a detected BPM value.
 
@@ -36,28 +36,47 @@ def _pick_best_tempo(
     actual tempo.  This function generates candidates by multiplying
     the detected value with a set of common musical ratios (half,
     double, third, quarter, etc.) and picks the candidate in the
-    expected range that is closest to *target* BPM.
+    expected range that is closest to a reference value.
+
+    The default range ``[50, 500]`` is intentionally wide because
+    UltraStar uses BPM as a **timing-resolution parameter**, not as
+    musical tempo.  Higher BPM means a finer beat grid and more
+    precise note placement.  The ``get_multiplier()`` function in
+    ``ultrastar_writer.py`` already compensates for low BPM values,
+    so aggressive downscaling toward a "typical" tempo is harmful.
 
     If the detected tempo already lies inside ``[low, high]`` it is
     returned unchanged -- ratio correction only applies to values
-    outside the expected range.  This prevents legitimate fast or slow
-    tempos (e.g. 180 BPM punk rock) from being rescaled.
+    outside the expected range.  This prevents legitimate tempos
+    from being rescaled.
 
-    When two candidates are equally close to *target*, the one derived
-    from the simpler ratio wins (identity > half/double > third, ...).
+    When *target* is ``None`` (default), the detected *primary_bpm*
+    itself is used as reference.  This means: when correction IS
+    needed, the candidate closest to the original value is picked,
+    avoiding any bias toward a particular tempo.
+
+    When two candidates are equally close to the reference, the one
+    derived from the simpler ratio wins (identity > half/double >
+    third, ...).
 
     Args:
         primary_bpm: The primary tempo estimate from librosa.
         low: Lower bound of the acceptable BPM range (inclusive).
         high: Upper bound of the acceptable BPM range (inclusive).
-        target: Preferred tempo centre -- candidates closest to this
-            value are selected.  120 BPM is a common pop/rock tempo.
+        target: Reference tempo for candidate selection.  When
+            ``None`` (default), the *primary_bpm* itself is used,
+            so correction picks the value closest to the detected
+            tempo.  Pass an explicit value (e.g. ``120.0``) to bias
+            toward a specific tempo centre.
 
     Returns:
         The corrected tempo in BPM.
     """
     if primary_bpm <= 0:
-        return target  # Fallback
+        return 120.0  # Fallback for invalid input
+
+    # Resolve effective target: default to the detected value itself
+    effective_target = target if target is not None else primary_bpm
 
     # Already in range -- trust the detector and return as-is.
     # Ratio correction should only kick in for out-of-range values;
@@ -69,15 +88,15 @@ def _pick_best_tempo(
     # Generate candidates from all ratios, preserving ratio order
     candidates = [primary_bpm * r for r in _TEMPO_RATIOS]
 
-    # Prefer candidates in the typical song range
+    # Prefer candidates in the acceptable range
     in_range = [c for c in candidates if low <= c <= high]
 
     if in_range:
-        # Pick the one closest to target BPM.
+        # Pick the one closest to the effective target.
         # Because _TEMPO_RATIOS is ordered by simplicity and min()
         # is stable (returns the first minimum), simpler ratios win
         # ties automatically.
-        return min(in_range, key=lambda x: abs(x - target))
+        return min(in_range, key=lambda x: abs(x - effective_target))
 
     # Nothing in range -- use the primary as-is
     return primary_bpm

--- a/src/modules/Audio/denoise.py
+++ b/src/modules/Audio/denoise.py
@@ -6,27 +6,34 @@ from modules.console_colors import ULTRASINGER_HEAD, blue_highlighted, green_hig
 from modules.os_helper import check_file_exists
 
 
-def __ffmpeg_reduce_noise(input_file_path: str, output_file: str) -> None:
-    """Reduce noise from vocal audio with ffmpeg."""
+def __ffmpeg_reduce_noise(input_file_path: str, output_file: str,
+                          noise_reduction: float = 20,
+                          noise_floor: float = -80,
+                          track_noise: bool = True) -> None:
+    """Reduce noise from vocal audio with ffmpeg.
 
-    # Denoise audio samples with FFT.
-    # A description of the accepted parameters follows.
+    Uses the afftdn (FFT-based denoising) filter.
 
-    # noise_reduction, nr
-    #    Set the noise reduction in dB, allowed range is 0.01 to 97. Default value is 12 dB.
-    # noise_floor, nf
-    #    Set the noise floor in dB, allowed range is -80 to -20. Default value is -50 dB.
-    # track_noise, tn
-    #    Enable noise floor tracking. By default is disabled.
-    #    With this enabled, noise floor is automatically adjusted.
+    Args:
+        input_file_path: Path to input audio file.
+        output_file: Path for denoised output file.
+        noise_reduction: Noise reduction in dB (0.01-97). Default: 20.
+            Lower values preserve more vocal detail (consonants, sibilants).
+            Higher values remove more noise but risk destroying vocal nuances.
+        noise_floor: Noise floor in dB (-80 to -20). Default: -80.
+        track_noise: Enable adaptive noise floor tracking. Default: True.
+    """
+
+    tn_flag = 1 if track_noise else 0
+    af_filter = f"afftdn=nr={noise_reduction}:nf={noise_floor}:tn={tn_flag}"
 
     print(
-        f"{ULTRASINGER_HEAD} Reduce noise from vocal audio with {blue_highlighted('ffmpeg')}."
+        f"{ULTRASINGER_HEAD} Reduce noise from vocal audio with {blue_highlighted('ffmpeg')} (nr={noise_reduction}dB, nf={noise_floor}dB)."
     )
     try:
         (
             ffmpeg.input(input_file_path)
-            .output(output_file, af="afftdn=nr=70:nf=-80:tn=1")
+            .output(output_file, af=af_filter)
             .overwrite_output()
             .run(capture_stdout=True, capture_stderr=True)
         )
@@ -36,10 +43,17 @@ def __ffmpeg_reduce_noise(input_file_path: str, output_file: str) -> None:
         raise ffmpeg_exception
 
 
-def denoise_vocal_audio(input_path: str, output_path: str, skip_cache: bool = False) -> None:
+def denoise_vocal_audio(input_path: str, output_path: str,
+                        skip_cache: bool = False,
+                        noise_reduction: float = 20,
+                        noise_floor: float = -80,
+                        track_noise: bool = True) -> None:
     """Denoise vocal audio"""
     cache_available = check_file_exists(output_path)
     if skip_cache or not cache_available:
-        __ffmpeg_reduce_noise(input_path, output_path)
+        __ffmpeg_reduce_noise(input_path, output_path,
+                              noise_reduction=noise_reduction,
+                              noise_floor=noise_floor,
+                              track_noise=track_noise)
     else:
         print(f"{ULTRASINGER_HEAD} {green_highlighted('cache')} reusing cached denoised audio")

--- a/src/modules/Audio/vocal_chunks.py
+++ b/src/modules/Audio/vocal_chunks.py
@@ -109,7 +109,7 @@ def create_audio_chunks_from_transcribed_data(
 
     csv_filename = os.path.join(audio_chunks_path, "_chunks.csv")
     __export_chunks_from_transcribed_data(
-        process_data_paths.processing_audio_path, transcribed_data, audio_chunks_path
+        process_data_paths.whisper_audio_path, transcribed_data, audio_chunks_path
     )
     export_transcribed_data_to_csv(transcribed_data, csv_filename)
 

--- a/src/modules/Audio/youtube.py
+++ b/src/modules/Audio/youtube.py
@@ -13,11 +13,26 @@ from modules.musicbrainz_client import search_musicbrainz
 from modules.ffmpeg_helper import separate_audio_video
 
 
-def get_youtube_title(url: str, cookiefile: str = None) -> tuple[str, str]:
+def _cookie_opts(cookiefile: str = None, cookies_from_browser: str = None) -> dict:
+    """Build yt-dlp cookie options.
+
+    ``cookies_from_browser`` takes precedence over ``cookiefile`` because
+    it reads fresh session cookies directly from the browser, avoiding
+    the common issue of exported cookie files going stale.
+    """
+    opts = {}
+    if cookies_from_browser:
+        opts["cookiesfrombrowser"] = (cookies_from_browser,)
+    elif cookiefile:
+        opts["cookiefile"] = cookiefile
+    return opts
+
+
+def get_youtube_title(url: str, cookiefile: str = None, cookies_from_browser: str = None) -> tuple[str, str]:
     """Get the title of the YouTube video"""
 
     ydl_opts = {
-        "cookiefile": cookiefile,
+        **_cookie_opts(cookiefile, cookies_from_browser),
     }
     with yt_dlp.YoutubeDL(ydl_opts) as ydl:
         result = ydl.extract_info(
@@ -31,7 +46,7 @@ def get_youtube_title(url: str, cookiefile: str = None) -> tuple[str, str]:
     return result["channel"].strip(), result["title"].strip()
 
 
-def __download_youtube_video_with_audio(url: str, clear_filename: str, output_path: str, cookiefile: str = None) -> str:
+def __download_youtube_video_with_audio(url: str, clear_filename: str, output_path: str, cookiefile: str = None, cookies_from_browser: str = None) -> str:
     """Download video with audio from YouTube and return the file extension"""
 
     print(f"{ULTRASINGER_HEAD} Downloading Video with Audio")
@@ -39,20 +54,20 @@ def __download_youtube_video_with_audio(url: str, clear_filename: str, output_pa
         "format": "bestvideo[ext=mp4]+bestaudio/best",
         "outtmpl": output_path + "/" + clear_filename + ".%(ext)s",
         "merge_output_format": "mp4",
-        "cookiefile": cookiefile,
+        **_cookie_opts(cookiefile, cookies_from_browser),
     }
     __start_download(ydl_opts, url)
     return "mp4"
 
 
-def __download_youtube_thumbnail(url: str, clear_filename: str, output_path: str, cookiefile: str = None) -> str:
+def __download_youtube_thumbnail(url: str, clear_filename: str, output_path: str, cookiefile: str = None, cookies_from_browser: str = None) -> str:
     """Download thumbnail from YouTube"""
 
     print(f"{ULTRASINGER_HEAD} Downloading thumbnail")
     ydl_opts = {
         "skip_download": True,
         "writethumbnail": True,
-        "cookiefile": cookiefile,
+        **_cookie_opts(cookiefile, cookies_from_browser),
     }
 
     thumbnail_url = download_and_convert_thumbnail(ydl_opts, url, clear_filename, output_path)
@@ -85,9 +100,9 @@ def __start_download(ydl_opts, url: str) -> None:
             raise Exception("Download failed with error: " + str(errors))
 
 
-def download_from_youtube(input_url: str, output_folder_path: str, cookiefile: str = None) -> tuple[str, str, str, MediaInfo]:
+def download_from_youtube(input_url: str, output_folder_path: str, cookiefile: str = None, cookies_from_browser: str = None) -> tuple[str, str, str, MediaInfo]:
     """Download from YouTube"""
-    (artist, title) = get_youtube_title(input_url, cookiefile)
+    (artist, title) = get_youtube_title(input_url, cookiefile, cookies_from_browser)
 
     # Get additional data for song
     song_info = search_musicbrainz(title, artist)
@@ -99,7 +114,7 @@ def download_from_youtube(input_url: str, output_folder_path: str, cookiefile: s
 
     print(f"{ULTRASINGER_HEAD} Downloading from YouTube")
     video_ext = __download_youtube_video_with_audio(
-        input_url, basename_without_ext, song_output, cookiefile
+        input_url, basename_without_ext, song_output, cookiefile, cookies_from_browser
     )
     video_with_audio_path = os.path.join(song_output, f"{basename_without_ext}.{video_ext}")
 
@@ -113,7 +128,7 @@ def download_from_youtube(input_url: str, output_folder_path: str, cookiefile: s
         save_image(song_info.cover_image_data, basename_without_ext, song_output)
     else:
         cover_url = __download_youtube_thumbnail(
-            input_url, basename_without_ext, song_output, cookiefile
+            input_url, basename_without_ext, song_output, cookiefile, cookies_from_browser
         )
 
     return (

--- a/src/modules/Audio/youtube.py
+++ b/src/modules/Audio/youtube.py
@@ -13,26 +13,11 @@ from modules.musicbrainz_client import search_musicbrainz
 from modules.ffmpeg_helper import separate_audio_video
 
 
-def _cookie_opts(cookiefile: str = None, cookies_from_browser: str = None) -> dict:
-    """Build yt-dlp cookie options.
-
-    ``cookies_from_browser`` takes precedence over ``cookiefile`` because
-    it reads fresh session cookies directly from the browser, avoiding
-    the common issue of exported cookie files going stale.
-    """
-    opts = {}
-    if cookies_from_browser:
-        opts["cookiesfrombrowser"] = (cookies_from_browser,)
-    elif cookiefile:
-        opts["cookiefile"] = cookiefile
-    return opts
-
-
-def get_youtube_title(url: str, cookiefile: str = None, cookies_from_browser: str = None) -> tuple[str, str]:
+def get_youtube_title(url: str, cookiefile: str = None) -> tuple[str, str]:
     """Get the title of the YouTube video"""
 
     ydl_opts = {
-        **_cookie_opts(cookiefile, cookies_from_browser),
+        "cookiefile": cookiefile,
     }
     with yt_dlp.YoutubeDL(ydl_opts) as ydl:
         result = ydl.extract_info(
@@ -46,7 +31,7 @@ def get_youtube_title(url: str, cookiefile: str = None, cookies_from_browser: st
     return result["channel"].strip(), result["title"].strip()
 
 
-def __download_youtube_video_with_audio(url: str, clear_filename: str, output_path: str, cookiefile: str = None, cookies_from_browser: str = None) -> str:
+def __download_youtube_video_with_audio(url: str, clear_filename: str, output_path: str, cookiefile: str = None) -> str:
     """Download video with audio from YouTube and return the file extension"""
 
     print(f"{ULTRASINGER_HEAD} Downloading Video with Audio")
@@ -54,20 +39,20 @@ def __download_youtube_video_with_audio(url: str, clear_filename: str, output_pa
         "format": "bestvideo[ext=mp4]+bestaudio/best",
         "outtmpl": output_path + "/" + clear_filename + ".%(ext)s",
         "merge_output_format": "mp4",
-        **_cookie_opts(cookiefile, cookies_from_browser),
+        "cookiefile": cookiefile,
     }
     __start_download(ydl_opts, url)
     return "mp4"
 
 
-def __download_youtube_thumbnail(url: str, clear_filename: str, output_path: str, cookiefile: str = None, cookies_from_browser: str = None) -> str:
+def __download_youtube_thumbnail(url: str, clear_filename: str, output_path: str, cookiefile: str = None) -> str:
     """Download thumbnail from YouTube"""
 
     print(f"{ULTRASINGER_HEAD} Downloading thumbnail")
     ydl_opts = {
         "skip_download": True,
         "writethumbnail": True,
-        **_cookie_opts(cookiefile, cookies_from_browser),
+        "cookiefile": cookiefile,
     }
 
     thumbnail_url = download_and_convert_thumbnail(ydl_opts, url, clear_filename, output_path)
@@ -100,9 +85,9 @@ def __start_download(ydl_opts, url: str) -> None:
             raise Exception("Download failed with error: " + str(errors))
 
 
-def download_from_youtube(input_url: str, output_folder_path: str, cookiefile: str = None, cookies_from_browser: str = None) -> tuple[str, str, str, MediaInfo]:
+def download_from_youtube(input_url: str, output_folder_path: str, cookiefile: str = None) -> tuple[str, str, str, MediaInfo]:
     """Download from YouTube"""
-    (artist, title) = get_youtube_title(input_url, cookiefile, cookies_from_browser)
+    (artist, title) = get_youtube_title(input_url, cookiefile)
 
     # Get additional data for song
     song_info = search_musicbrainz(title, artist)
@@ -114,7 +99,7 @@ def download_from_youtube(input_url: str, output_folder_path: str, cookiefile: s
 
     print(f"{ULTRASINGER_HEAD} Downloading from YouTube")
     video_ext = __download_youtube_video_with_audio(
-        input_url, basename_without_ext, song_output, cookiefile, cookies_from_browser
+        input_url, basename_without_ext, song_output, cookiefile
     )
     video_with_audio_path = os.path.join(song_output, f"{basename_without_ext}.{video_ext}")
 
@@ -128,7 +113,7 @@ def download_from_youtube(input_url: str, output_folder_path: str, cookiefile: s
         save_image(song_info.cover_image_data, basename_without_ext, song_output)
     else:
         cover_url = __download_youtube_thumbnail(
-            input_url, basename_without_ext, song_output, cookiefile, cookies_from_browser
+            input_url, basename_without_ext, song_output, cookiefile
         )
 
     return (

--- a/src/modules/Midi/midi_creator.py
+++ b/src/modules/Midi/midi_creator.py
@@ -299,7 +299,9 @@ def correct_global_octave(
 
 
 def correct_octave_outliers(
-    midi_segments: list[MidiSegment], window: int = 5
+    midi_segments: list[MidiSegment],
+    window: int = 5,
+    passes: int = 2,
 ) -> list[MidiSegment]:
     """Correct octave outliers by comparing each note to its neighbours.
 
@@ -308,9 +310,30 @@ def correct_octave_outliers(
     that is more than 11 semitones away from the local median back to the
     closest octave.
 
+    The correction operates in two phases:
+
+    **Phase 1 — Local passes:**  Multiple passes compare each note to
+    the median of its *window* neighbours.  Notes more than 11 semitones
+    away are shifted by whole octaves toward the local median.  When
+    several candidates are equally valid, the one closest to the *global*
+    median wins.  Multiple passes help because corrections from earlier
+    passes update neighbour values for later passes.
+
+    **Phase 2 — Global consensus:**  After local passes, some clusters
+    may remain uncorrected because the local neighbourhood was dominated
+    by wrong-octave notes (contaminated median).  When the majority of
+    notes agree on a particular octave region, this phase shifts notes
+    that are a full octave or more (≥ 12 semitones) from the global
+    median by whole octaves toward it.  Legitimate melody intervals
+    (< 12 semitones, e.g. a fifth or sixth) are never touched.
+    This only activates when a clear majority exists (> 50 % of notes
+    near the global median).
+
     Args:
         midi_segments: List of MIDI segments with ``.note`` attributes.
         window: Number of neighbours on each side to consider.
+        passes: Number of local correction passes (default 2).  Use
+            ``1`` for the legacy single-pass behaviour.
 
     Returns:
         The same list, with outlier notes corrected in-place.
@@ -318,44 +341,142 @@ def correct_octave_outliers(
     if len(midi_segments) < 3:
         return midi_segments
 
-    print(f"{ULTRASINGER_HEAD} Correcting octave outliers")
+    print(f"{ULTRASINGER_HEAD} Correcting octave outliers ({passes} pass{'es' if passes != 1 else ''})")
 
-    midi_values = []
+    # ── Phase 1: Local outlier correction ────────────────────────────
+    for _pass_num in range(passes):
+        # Rebuild MIDI values from current notes at the start of each pass
+        midi_values: list[int | None] = []
+        for seg in midi_segments:
+            try:
+                midi_values.append(librosa.note_to_midi(seg.note))
+            except (ValueError, KeyError):
+                midi_values.append(None)
+
+        # Compute global median once per pass as tie-breaker reference
+        valid_values = [v for v in midi_values if v is not None]
+        if not valid_values:
+            break
+        global_median = float(np.median(valid_values))
+
+        # Collect all corrections first, then apply them after the scan.
+        # This prevents earlier corrections from leaking into the
+        # neighbourhood of later notes within the same pass.
+        pending_updates: list[tuple[int, int]] = []
+
+        for i, seg in enumerate(midi_segments):
+            if midi_values[i] is None:
+                continue
+
+            # Collect valid neighbour MIDI values
+            lo = max(0, i - window)
+            hi = min(len(midi_segments), i + window + 1)
+            neighbours = [
+                midi_values[j]
+                for j in range(lo, hi)
+                if j != i and midi_values[j] is not None
+            ]
+
+            if not neighbours:
+                continue
+
+            median_neighbour = float(np.median(neighbours))
+            current = midi_values[i]
+
+            # Check if note is an outlier (> 11 semitones from local median)
+            if abs(current - median_neighbour) <= 11:
+                continue
+
+            # Generate all octave-shifted candidates within 11 ST of local median
+            candidates = []
+            shifted = current
+            # Shift down
+            while shifted > median_neighbour - 12:
+                if abs(shifted - median_neighbour) <= 11:
+                    candidates.append(shifted)
+                shifted -= 12
+            # Shift up from original
+            shifted = current + 12
+            while shifted < median_neighbour + 12:
+                if abs(shifted - median_neighbour) <= 11:
+                    candidates.append(shifted)
+                shifted += 12
+
+            if not candidates:
+                # Fallback: simple shift toward local median
+                shifted = current
+                while abs(shifted - median_neighbour) > 11:
+                    if shifted > median_neighbour:
+                        shifted -= 12
+                    else:
+                        shifted += 12
+                candidates = [shifted]
+
+            # Pick candidate closest to global median (tie-breaker)
+            best = min(candidates, key=lambda x: abs(x - global_median))
+
+            if best != midi_values[i]:
+                pending_updates.append((i, best))
+
+        # Apply all corrections from this pass at once
+        for i, best in pending_updates:
+            midi_segments[i].note = librosa.midi_to_note(best)
+
+        if not pending_updates:
+            # No changes this pass — further passes won't help
+            break
+
+    # ── Phase 2: Global consensus correction ─────────────────────────
+    # Fixes clusters that local correction couldn't handle because the
+    # local neighbourhood median was contaminated by wrong-octave notes.
+    midi_values_ph2: list[int | None] = []
     for seg in midi_segments:
         try:
-            midi_values.append(librosa.note_to_midi(seg.note))
-        except Exception:
-            midi_values.append(None)
+            midi_values_ph2.append(librosa.note_to_midi(seg.note))
+        except (ValueError, KeyError):
+            midi_values_ph2.append(None)
 
-    for i, seg in enumerate(midi_segments):
-        if midi_values[i] is None:
-            continue
+    valid_values = [v for v in midi_values_ph2 if v is not None]
+    if len(valid_values) >= 3:
+        global_median = float(np.median(valid_values))
 
-        # Collect valid neighbour MIDI values
-        lo = max(0, i - window)
-        hi = min(len(midi_segments), i + window + 1)
-        neighbours = [
-            midi_values[j]
-            for j in range(lo, hi)
-            if j != i and midi_values[j] is not None
-        ]
+        # Only apply when there is a clear majority near the global median
+        near_global = sum(
+            1 for v in valid_values if abs(v - global_median) <= 6
+        )
+        if near_global / len(valid_values) > 0.5:
+            consensus_corrections = 0
+            for i, seg in enumerate(midi_segments):
+                if midi_values_ph2[i] is None:
+                    continue
+                current = midi_values_ph2[i]
 
-        if not neighbours:
-            continue
+                # Only target notes that are a full octave or more from the
+                # global median — these are true octave errors.  Notes
+                # within 11 semitones are legitimate melody intervals
+                # (e.g. G4 is 7 ST from C4 and must NOT be shifted).
+                if abs(current - global_median) < 12:
+                    continue
 
-        median_neighbour = float(np.median(neighbours))
-        current = midi_values[i]
+                # Try octave shifts (±12, ±24) to get closer to global median
+                best = current
+                for shift in [-24, -12, 12, 24]:
+                    candidate = current + shift
+                    if abs(candidate - global_median) < abs(best - global_median):
+                        best = candidate
 
-        # Shift by octaves until within 11 semitones of the median
-        while abs(current - median_neighbour) > 11:
-            if current > median_neighbour:
-                current -= 12
-            else:
-                current += 12
+                # Only apply if the shift brings the note reasonably close
+                if best != current and abs(best - global_median) <= 11:
+                    seg.note = librosa.midi_to_note(best)
+                    midi_values_ph2[i] = best
+                    consensus_corrections += 1
 
-        if current != midi_values[i]:
-            seg.note = librosa.midi_to_note(current)
-            midi_values[i] = current
+            if consensus_corrections > 0:
+                print(
+                    f"{ULTRASINGER_HEAD} Global consensus: corrected "
+                    f"{blue_highlighted(str(consensus_corrections))} "
+                    f"cluster note{'s' if consensus_corrections != 1 else ''}"
+                )
 
     return midi_segments
 

--- a/src/modules/Midi/midi_creator.py
+++ b/src/modules/Midi/midi_creator.py
@@ -230,6 +230,68 @@ def create_repitched_midi_segments_from_ultrastar_txt(pitched_data: PitchedData,
     return midi_segments
 
 
+def correct_octave_outliers(
+    midi_segments: list[MidiSegment], window: int = 5
+) -> list[MidiSegment]:
+    """Correct octave outliers by comparing each note to its neighbours.
+
+    Pitch detectors occasionally jump a note into the wrong octave
+    (e.g. C2 instead of C4).  This post-processing step shifts any note
+    that is more than 11 semitones away from the local median back to the
+    closest octave.
+
+    Args:
+        midi_segments: List of MIDI segments with ``.note`` attributes.
+        window: Number of neighbours on each side to consider.
+
+    Returns:
+        The same list, with outlier notes corrected in-place.
+    """
+    if len(midi_segments) < 3:
+        return midi_segments
+
+    print(f"{ULTRASINGER_HEAD} Correcting octave outliers")
+
+    midi_values = []
+    for seg in midi_segments:
+        try:
+            midi_values.append(librosa.note_to_midi(seg.note))
+        except Exception:
+            midi_values.append(None)
+
+    for i, seg in enumerate(midi_segments):
+        if midi_values[i] is None:
+            continue
+
+        # Collect valid neighbour MIDI values
+        lo = max(0, i - window)
+        hi = min(len(midi_segments), i + window + 1)
+        neighbours = [
+            midi_values[j]
+            for j in range(lo, hi)
+            if j != i and midi_values[j] is not None
+        ]
+
+        if not neighbours:
+            continue
+
+        median_neighbour = float(np.median(neighbours))
+        current = midi_values[i]
+
+        # Shift by octaves until within 11 semitones of the median
+        while abs(current - median_neighbour) > 11:
+            if current > median_neighbour:
+                current -= 12
+            else:
+                current += 12
+
+        if current != midi_values[i]:
+            seg.note = librosa.midi_to_note(current)
+            midi_values[i] = current
+
+    return midi_segments
+
+
 def create_midi_file(
         real_bpm: float,
         song_output: str,

--- a/src/modules/Midi/midi_creator.py
+++ b/src/modules/Midi/midi_creator.py
@@ -230,6 +230,46 @@ def create_repitched_midi_segments_from_ultrastar_txt(pitched_data: PitchedData,
     return midi_segments
 
 
+def apply_octave_shift(
+    midi_segments: list[MidiSegment],
+    octaves: int,
+) -> list[MidiSegment]:
+    """Shift all notes by a fixed number of octaves.
+
+    This is a manual override for cases where automatic octave correction
+    fails (e.g. when the pitch detector consistently detects the wrong
+    octave but the median still falls in the expected vocal range).
+
+    Args:
+        midi_segments: List of MIDI segments with ``.note`` attributes.
+        octaves: Number of octaves to shift (positive = up, negative = down).
+
+    Returns:
+        The same list, with notes shifted in-place.
+    """
+    if not midi_segments or octaves == 0:
+        return midi_segments
+
+    shift = octaves * 12
+
+    print(
+        f"{ULTRASINGER_HEAD} Manual octave shift: "
+        f"shifting all notes by {blue_highlighted(f'{octaves:+d}')} octave(s) "
+        f"({shift:+d} semitones)"
+    )
+
+    for seg in midi_segments:
+        try:
+            current = librosa.note_to_midi(seg.note)
+            new_midi = current + shift
+            if 0 <= new_midi <= 127:
+                seg.note = librosa.midi_to_note(new_midi)
+        except (ValueError, TypeError):
+            print(f"{ULTRASINGER_HEAD} Skipping invalid note in octave shift: {seg.note!r}")
+
+    return midi_segments
+
+
 def correct_global_octave(
     midi_segments: list[MidiSegment],
     low: int = 48,

--- a/src/modules/Midi/midi_creator.py
+++ b/src/modules/Midi/midi_creator.py
@@ -230,6 +230,74 @@ def create_repitched_midi_segments_from_ultrastar_txt(pitched_data: PitchedData,
     return midi_segments
 
 
+def correct_global_octave(
+    midi_segments: list[MidiSegment],
+    low: int = 48,
+    high: int = 84,
+) -> list[MidiSegment]:
+    """Shift all notes by whole octaves so the median lies in the vocal range.
+
+    Pitch detectors sometimes lock onto a sub-harmonic (e.g. half the
+    fundamental frequency), pushing *every* note into an implausibly low
+    register.  :func:`correct_octave_outliers` only fixes *local*
+    outliers relative to their neighbours and cannot detect such a
+    *global* shift.
+
+    This function computes the median MIDI value of the entire song.
+    If that median falls outside the expected vocal range
+    (default ``48``-``84``, i.e. C3-C6), it shifts **all** notes by
+    the smallest multiple of 12 semitones needed to bring the median
+    inside the range.
+
+    Args:
+        midi_segments: List of MIDI segments with ``.note`` attributes.
+        low: Lower bound of the expected vocal MIDI range (inclusive).
+        high: Upper bound of the expected vocal MIDI range (inclusive).
+
+    Returns:
+        The same list, with notes corrected in-place.
+    """
+    if not midi_segments:
+        return midi_segments
+
+    midi_values = []
+    for seg in midi_segments:
+        try:
+            midi_values.append(librosa.note_to_midi(seg.note))
+        except (ValueError, TypeError):
+            pass
+
+    if not midi_values:
+        return midi_segments
+
+    median_midi = float(np.median(midi_values))
+
+    # Already in range — nothing to do
+    if low <= median_midi <= high:
+        return midi_segments
+
+    # Find the smallest octave shift that brings the median into range
+    if median_midi < low:
+        shift = int(np.ceil((low - median_midi) / 12)) * 12
+    else:
+        shift = -int(np.ceil((median_midi - high) / 12)) * 12
+
+    print(
+        f"{ULTRASINGER_HEAD} Global octave correction: "
+        f"shifting all notes by {blue_highlighted(f'{shift:+d}')} semitones "
+        f"(median was MIDI {median_midi:.0f}, target range {low}-{high})"
+    )
+
+    for seg in midi_segments:
+        try:
+            current = librosa.note_to_midi(seg.note)
+            seg.note = librosa.midi_to_note(current + shift)
+        except (ValueError, TypeError):
+            pass
+
+    return midi_segments
+
+
 def correct_octave_outliers(
     midi_segments: list[MidiSegment], window: int = 5
 ) -> list[MidiSegment]:

--- a/src/modules/Midi/midi_creator.py
+++ b/src/modules/Midi/midi_creator.py
@@ -2,7 +2,6 @@
 
 import math
 import os
-from collections import Counter
 
 import librosa
 import numpy as np
@@ -58,17 +57,57 @@ class MidiCreator:
     """Docstring"""
 
 
-def convert_frequencies_to_notes(frequency: [str]) -> list[list[str]]:
-    """Converts frequencies to notes"""
-    notes = []
-    for freq in frequency:
-        notes.append(librosa.hz_to_note(float(freq)))
-    return notes
+def confidence_weighted_median_note(
+    frequencies: list[float], weights: list[float]
+) -> str:
+    """Select a note using the confidence-weighted median of frequencies.
 
+    Instead of converting frequencies to note names first and picking the
+    mode (most common), this operates on raw Hz values so that the median
+    is computed in a continuous space.  This avoids the problem where
+    pitch jitter across note boundaries causes the mode to pick a rare
+    outlier note.
 
-def most_frequent(array: [str]) -> list[tuple[str, int]]:
-    """Get most frequent item in array"""
-    return Counter(array).most_common(1)
+    Args:
+        frequencies: Detected frequencies in Hz (already confidence-filtered).
+        weights: Confidence values corresponding to each frequency.
+
+    Returns:
+        Note name string (e.g. ``"C4"``).
+
+    Raises:
+        ValueError: If *frequencies* or *weights* are empty, have
+            mismatched lengths, or all weights are zero.
+    """
+    if not frequencies or not weights:
+        raise ValueError("frequencies and weights must be non-empty")
+    if len(frequencies) != len(weights):
+        raise ValueError(
+            f"frequencies ({len(frequencies)}) and weights ({len(weights)}) "
+            "must have the same length"
+        )
+
+    freqs = np.asarray(frequencies, dtype=float)
+    wts = np.asarray(weights, dtype=float)
+
+    total_weight = wts.sum()
+    if total_weight == 0:
+        raise ValueError("total weight must be > 0")
+
+    # Sort by frequency
+    order = np.argsort(freqs)
+    sorted_freqs = freqs[order]
+    sorted_wts = wts[order]
+
+    # Weighted median: first cumulative weight index >= half total weight
+    cumulative = np.cumsum(sorted_wts)
+    half = total_weight / 2.0
+    median_idx = int(np.searchsorted(cumulative, half))
+    # Clamp to valid index range
+    median_idx = min(median_idx, len(sorted_freqs) - 1)
+    median_freq = sorted_freqs[median_idx]
+
+    return librosa.hz_to_note(float(median_freq))
 
 
 def find_nearest_index(array: list[float], value: float) -> int:
@@ -138,11 +177,13 @@ def create_midi_note_from_pitched_data(start_time: float, end_time: float, pitch
         freqs = pitched_data.frequencies[start:end]
         confs = pitched_data.confidence[start:end]
 
-    conf_f = get_frequencies_with_high_confidence(freqs, confs)
+    conf_f, conf_weights = get_frequencies_with_high_confidence(freqs, confs)
 
-    notes = convert_frequencies_to_notes(conf_f)
-
-    note = most_frequent(notes)[0][0]
+    if not conf_f:
+        # No valid frequencies found; fall back to a neutral middle note
+        note = "C4"
+    else:
+        note = confidence_weighted_median_note(conf_f, conf_weights)
 
     if allowed_notes is not None:
         note = quantize_note_to_key(note, allowed_notes)

--- a/src/modules/Pitcher/pitched_data.py
+++ b/src/modules/Pitcher/pitched_data.py
@@ -7,7 +7,7 @@ from dataclasses_json import dataclass_json
 @dataclass_json
 @dataclass
 class PitchedData:
-    """Pitched data from crepe"""
+    """Pitched data from pitch detection (SwiftF0)"""
 
     times: list[float]
     frequencies: list[float]

--- a/src/modules/Pitcher/pitched_data_helper.py
+++ b/src/modules/Pitcher/pitched_data_helper.py
@@ -1,12 +1,39 @@
 """Pitched data helper module"""
+
+
 def get_frequencies_with_high_confidence(
     frequencies: list[float], confidences: list[float], threshold=0.4
-) -> list[float]:
-    """Get frequency with high confidence"""
+) -> tuple[list[float], list[float]]:
+    """Get frequencies with high confidence and their corresponding weights.
+
+    Filters frequencies by a confidence threshold. If no frequency passes
+    the threshold, falls back to the top 25% by confidence instead of
+    returning all frequencies (which would include low-confidence noise).
+
+    Args:
+        frequencies: List of detected frequencies (Hz).
+        confidences: List of confidence values (0.0-1.0) for each frequency.
+        threshold: Minimum confidence to accept a frequency (default 0.4).
+
+    Returns:
+        Tuple of (filtered_frequencies, confidence_weights).
+    """
     conf_f = []
+    conf_weights = []
     for i, conf in enumerate(confidences):
         if conf > threshold:
             conf_f.append(frequencies[i])
+            conf_weights.append(conf)
+
     if not conf_f:
-        conf_f = frequencies
-    return conf_f
+        # Fallback: use top 25% by confidence instead of ALL frequencies.
+        # This avoids flooding the result with low-confidence noise frames.
+        if confidences:
+            indexed = list(enumerate(confidences))
+            indexed.sort(key=lambda x: x[1], reverse=True)
+            top_n = max(1, len(indexed) // 4)
+            for idx, conf in indexed[:top_n]:
+                conf_f.append(frequencies[idx])
+                conf_weights.append(conf)
+
+    return conf_f, conf_weights

--- a/src/modules/ProcessData.py
+++ b/src/modules/ProcessData.py
@@ -8,7 +8,8 @@ from typing import Optional, List
 @dataclass
 class ProcessDataPaths:
     # Process data Paths
-    processing_audio_path: Optional[str] = ""
+    processing_audio_path: Optional[str] = ""  # Muted audio for pitch detection
+    whisper_audio_path: Optional[str] = ""  # Un-muted audio for Whisper transcription
     cache_folder_path: Optional[str] = ""
     audio_output_file_path: Optional[str] = "" # Output audio file path
     vocals_audio_file_path: Optional[str] = "" # Separated vocals audio file path

--- a/src/modules/Ultrastar/ultrastar_writer.py
+++ b/src/modules/Ultrastar/ultrastar_writer.py
@@ -3,6 +3,7 @@
 import math
 import re
 import langcodes
+import numpy as np
 from packaging import version
 
 from modules.console_colors import ULTRASINGER_HEAD
@@ -140,8 +141,9 @@ def create_ultrastar_txt(
                 separated_word_silence.append(silence)
                 continue
 
-            if i != len(midi_segments) - 1 and silence_split_duration != 0 and silence > silence_split_duration or any(
-                    s > silence_split_duration for s in separated_word_silence):
+            if silence_split_duration is not None and (
+                    i != len(midi_segments) - 1 and silence > silence_split_duration
+                    or any(s > silence_split_duration for s in separated_word_silence)):
                 # - 10
                 # '-' end of current sing part
                 # 'n1' show next at time in real beat
@@ -156,33 +158,59 @@ def create_ultrastar_txt(
         file.write(f"{UltrastarTxtTag.FILE_END.value}")
 
 
-def deviation(silence_parts):
-    """Calculates the deviation of the silence parts"""
+def silence_threshold(
+    silence_parts: list[float], percentile: float = 75
+) -> float | None:
+    """Calculate the silence duration threshold for linebreaks.
 
+    Uses a percentile-based approach: only silences above the given
+    percentile of all inter-note gaps trigger a linebreak.  This is
+    more robust than a mean-based approach, which either creates too
+    many linebreaks (when pauses are evenly distributed) or too few
+    (when a single long pause skews the average).
+
+    Args:
+        silence_parts: List of silence durations in seconds between
+            consecutive notes.
+        percentile: The percentile of silence durations to use as the
+            threshold (default 75 — only the longest 25 % of gaps
+            become linebreaks).
+
+    Returns:
+        The silence duration threshold in seconds, or ``None`` when
+        there are fewer than 5 gaps (too few to compute a meaningful
+        threshold).  Callers must check for ``None`` before comparing.
+    """
     if len(silence_parts) < 5:
-        return 0
+        return None
 
-    # Remove the longest part so the deviation is not that high
-    sorted_parts = sorted(silence_parts)
-    filtered_parts = [part for part in sorted_parts if part < sorted_parts[-1]]
-
-    sum_parts = sum(filtered_parts)
-    if sum_parts == 0:
-        return 0
-
-    mean = sum_parts / len(filtered_parts)
-    return mean
+    return float(np.percentile(silence_parts, percentile))
 
 
-def calculate_silent_beat_length(midi_segments: list[MidiSegment]):
+def calculate_silent_beat_length(
+    midi_segments: list[MidiSegment], percentile: float = 75
+) -> float | None:
+    """Extract inter-note silence durations and compute a threshold.
+
+    This is a convenience wrapper around :func:`silence_threshold`
+    that collects the gaps between consecutive MIDI segments.
+
+    Args:
+        midi_segments: List of MIDI segments with start/end times.
+        percentile: Passed to :func:`silence_threshold`.
+
+    Returns:
+        The silence duration threshold (see :func:`silence_threshold`).
+    """
     print(f"{ULTRASINGER_HEAD} Calculating silence parts for linebreaks.")
 
     silent_parts = []
     for i, data in enumerate(midi_segments):
         if i < len(midi_segments) - 1:
-            silent_parts.append(midi_segments[i + 1].start - data.end)
+            silence = max(0, midi_segments[i + 1].start - data.end)
+            silent_parts.append(silence)
 
-    return deviation(silent_parts)
+    return silence_threshold(silent_parts, percentile)
 
 
 def create_repitched_txt_from_ultrastar_data(

--- a/src/modules/Ultrastar/ultrastar_writer.py
+++ b/src/modules/Ultrastar/ultrastar_writer.py
@@ -1,5 +1,6 @@
 """Ultrastar writer module"""
 
+import math
 import re
 import langcodes
 from packaging import version
@@ -16,17 +17,20 @@ from modules.Midi.MidiSegment import MidiSegment
 
 
 def get_multiplier(real_bpm: float) -> int:
-    """Calculates the multiplier for the BPM"""
+    """Calculates the multiplier so that real_bpm * multiplier >= 400.
 
-    if real_bpm == 0:
-        raise Exception("BPM is 0")
+    A higher multiplier gives finer beat resolution, reducing rounding errors
+    when converting seconds to integer beats. The threshold of 400 ensures
+    at least ~6.67 beats per second at the lowest BPM.
+    """
+
+    if real_bpm <= 0:
+        raise Exception("BPM must be positive")
 
     multiplier = 1
-    result = 0
-    while result < 400:
-        result = real_bpm * multiplier
+    while real_bpm * multiplier < 400:
         multiplier += 1
-    return multiplier - 2
+    return multiplier
 
 
 def get_language_name(language: str) -> str:
@@ -46,7 +50,7 @@ def create_ultrastar_txt(
 
     ultrastar_bpm = real_bpm_to_ultrastar_bpm(real_bpm)
     multiplication = get_multiplier(ultrastar_bpm)
-    ultrastar_bpm = ultrastar_bpm * get_multiplier(ultrastar_bpm)
+    ultrastar_bpm = ultrastar_bpm * multiplication
     silence_split_duration = calculate_silent_beat_length(midi_segments)
 
     with open(ultrastar_file_output, "w", encoding=FILE_ENCODING) as file:
@@ -97,14 +101,18 @@ def create_ultrastar_txt(
 
         for i, midi_segment in enumerate(midi_segments):
             start_time = (midi_segment.start - gap) * multiplication
-            end_time = (
-                               midi_segment.end - midi_segment.start
-                       ) * multiplication
-            start_beat = round(second_to_beat(start_time, real_bpm))
-            duration = round(second_to_beat(end_time, real_bpm))
+            end_time = (midi_segment.end - midi_segment.start) * multiplication
 
-            # Fix the round issue, so the beats don’t overlap
-            start_beat = max(start_beat, previous_end_beat)
+            # Use floor for start (prefer slightly early over late) and
+            # max(1, ...) for duration (every note must be at least 1 beat).
+            # round() caused ±0.5 beat errors that accumulated over the song
+            # because max() below only shifts notes later, never earlier.
+            start_beat = math.floor(second_to_beat(start_time, real_bpm))
+            duration = max(1, math.ceil(second_to_beat(end_time, real_bpm)))
+
+            # Prevent overlap: shift start to after previous note if needed
+            if start_beat < previous_end_beat:
+                start_beat = previous_end_beat
             previous_end_beat = start_beat + duration
 
             # Calculate the silence between the words
@@ -142,7 +150,7 @@ def create_ultrastar_txt(
                         * multiplication
                 )
                 linebreak = f"{UltrastarTxtTag.LINEBREAK.value} " \
-                            f"{str(round(show_next))}\n"
+                            f"{str(math.floor(show_next))}\n"
                 file.write(linebreak)
             separated_word_silence = []
         file.write(f"{UltrastarTxtTag.FILE_END.value}")

--- a/src/modules/Ultrastar/ultrastar_writer.py
+++ b/src/modules/Ultrastar/ultrastar_writer.py
@@ -159,7 +159,7 @@ def create_ultrastar_txt(
 
 
 def silence_threshold(
-    silence_parts: list[float], percentile: float = 75
+    silence_parts: list[float], percentile: float = 85
 ) -> float | None:
     """Calculate the silence duration threshold for linebreaks.
 
@@ -173,8 +173,10 @@ def silence_threshold(
         silence_parts: List of silence durations in seconds between
             consecutive notes.
         percentile: The percentile of silence durations to use as the
-            threshold (default 75 — only the longest 25 % of gaps
-            become linebreaks).
+            threshold (default 85 — only the longest 15 % of gaps
+            become linebreaks).  A higher percentile produces fewer
+            linebreaks; 85 was chosen empirically to match the density
+            of manually-authored UltraStar files.
 
     Returns:
         The silence duration threshold in seconds, or ``None`` when
@@ -188,7 +190,7 @@ def silence_threshold(
 
 
 def calculate_silent_beat_length(
-    midi_segments: list[MidiSegment], percentile: float = 75
+    midi_segments: list[MidiSegment], percentile: float = 85
 ) -> float | None:
     """Extract inter-note silence durations and compute a threshold.
 

--- a/src/modules/common_print.py
+++ b/src/modules/common_print.py
@@ -60,6 +60,11 @@ def print_help() -> None:
     --keep_numbers          Transcribe numbers as digits and not words
     --ffmpeg                Path to ffmpeg and ffprobe executable
 
+    [denoise]
+    --denoise_nr            Noise reduction in dB (0.01-97). Lower preserves more vocal detail. >> ((default) is 20)
+    --denoise_nf            Noise floor in dB (-80 to -20) >> ((default) is -80)
+    --disable_denoise_track_noise  Disable adaptive noise floor tracking >> ((default) tracking is enabled)
+
     [yt-dlp]
     --cookiefile            File name where cookies should be read from and dumped to.
     

--- a/src/modules/common_print.py
+++ b/src/modules/common_print.py
@@ -42,11 +42,6 @@ def print_help() -> None:
     --whisper_compute_type  Change to "int8" if low on GPU mem (may reduce accuracy) >> ((default) is "float16" for cuda devices, "int8" for cpu)
     --keep_numbers          Numbers will be transcribed as numerics instead of as words >> True|False >> ((default) is False)
     
-    [pitcher]
-    # Default is crepe
-    --crepe            tiny|full >> ((default) is full)
-    --crepe_step_size  unit is miliseconds >> ((default) is 10)
-    
     [extra]
     --bpm                   Override auto-detected BPM with a manual value (e.g., --bpm 340)
     --disable_hyphenation   Disable word hyphenation. Hyphenation is enabled by default.
@@ -72,7 +67,6 @@ def print_help() -> None:
     [device]
     --force_cpu             Force all steps to be processed on CPU.
     --force_whisper_cpu     Force whisper transcription to be processed on CPU.
-    --force_crepe_cpu       Force crepe pitch detection to be processed on CPU.
     """
     print(help_string)
 

--- a/src/modules/common_print.py
+++ b/src/modules/common_print.py
@@ -66,10 +66,7 @@ def print_help() -> None:
     --disable_denoise_track_noise  Disable adaptive noise floor tracking >> ((default) tracking is enabled)
 
     [yt-dlp]
-    --cookiefile            Path to a Netscape-format cookies.txt file for YouTube authentication.
-    --cookies_from_browser  Browser to read cookies from (e.g. chrome, firefox, edge, opera, brave).
-                            Reads fresh session cookies directly, avoiding stale cookie files.
-                            Takes precedence over --cookiefile if both are provided.
+    --cookiefile            File name where cookies should be read from and dumped to.
     
     [device]
     --force_cpu             Force all steps to be processed on CPU.

--- a/src/modules/common_print.py
+++ b/src/modules/common_print.py
@@ -48,6 +48,7 @@ def print_help() -> None:
     --crepe_step_size  unit is miliseconds >> ((default) is 10)
     
     [extra]
+    --bpm                   Override auto-detected BPM with a manual value (e.g., --bpm 340)
     --disable_hyphenation   Disable word hyphenation. Hyphenation is enabled by default.
     --disable_separation    Disable track separation. Track separation is enabled by default.
     --disable_karaoke       Disable creation of karaoke style txt file. Karaoke is enabled by default.

--- a/src/modules/common_print.py
+++ b/src/modules/common_print.py
@@ -66,7 +66,10 @@ def print_help() -> None:
     --disable_denoise_track_noise  Disable adaptive noise floor tracking >> ((default) tracking is enabled)
 
     [yt-dlp]
-    --cookiefile            File name where cookies should be read from and dumped to.
+    --cookiefile            Path to a Netscape-format cookies.txt file for YouTube authentication.
+    --cookies_from_browser  Browser to read cookies from (e.g. chrome, firefox, edge, opera, brave).
+                            Reads fresh session cookies directly, avoiding stale cookie files.
+                            Takes precedence over --cookiefile if both are provided.
     
     [device]
     --force_cpu             Force all steps to be processed on CPU.

--- a/src/modules/common_print.py
+++ b/src/modules/common_print.py
@@ -55,7 +55,7 @@ def print_help() -> None:
     --create_audio_chunks   Enable creation of audio chunks. Audio chunks are disabled by default.
     --keep_cache            Keep cache folder after creation. Cache folder is removed by default.
     --plot                  Enable creation of plots. Plots are disabled by default.
-    --quantize_to_key       Quantize notes to the detected musical key. This removes slides and out-of-key notes.
+    --disable_quantization  Disable key quantization. Key quantization is enabled by default and removes slides and out-of-key notes.
     --format_version        0.3.0|1.0.0|1.1.0|1.2.0 >> ((default) is 1.2.0)
     --musescore_path        path to MuseScore executable
     --keep_numbers          Transcribe numbers as digits and not words

--- a/src/modules/ffmpeg_helper.py
+++ b/src/modules/ffmpeg_helper.py
@@ -135,10 +135,50 @@ def get_audio_codec_and_extension(video_file_path: str) -> str:
         return "wav"
 
 
+def convert_to_ultrastar_format(audio_file_path: str, basename_without_ext: str, output_folder: str, audio_ext: str) -> tuple[str, str]:
+    """
+    Convert audio to an UltraStar-compatible format (ogg) if needed.
+    UltraStar Play only supports mp3, ogg, and wav.
+    Returns the (possibly updated) audio file path and extension.
+    """
+    ULTRASTAR_COMPATIBLE_FORMATS = {"mp3", "ogg", "wav"}
+
+    if audio_ext in ULTRASTAR_COMPATIBLE_FORMATS:
+        return audio_file_path, audio_ext
+
+    from modules.console_colors import ULTRASINGER_HEAD
+
+    target_ext = "ogg"
+    target_path = os.path.join(output_folder, f"{basename_without_ext}.{target_ext}")
+    ffmpeg_path, _ = get_ffmpeg_and_ffprobe_paths()
+
+    print(f"{ULTRASINGER_HEAD} Converting {audio_ext} to {target_ext} (UltraStar compatibility)")
+
+    cmd = [
+        ffmpeg_path,
+        "-i", audio_file_path,
+        "-y",
+        "-loglevel", "error",
+        "-codec:a", "libvorbis",
+        "-q:a", "6",  # High quality VBR (~192 kbps)
+        target_path,
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise Exception(f"FFmpeg audio conversion to {target_ext} failed: {result.stderr}")
+
+    # Remove the original incompatible audio file
+    os.remove(audio_file_path)
+
+    return target_path, target_ext
+
+
 def separate_audio_video(video_with_audio_path: str, basename_without_ext: str, output_folder: str) -> tuple[str, str, str, str]:
     """
     Separate audio and video from a video file.
     Automatically detects the audio codec and uses the appropriate file extension.
+    Converts to ogg if the audio format is not supported by UltraStar Play.
     """
     from modules.console_colors import ULTRASINGER_HEAD
 
@@ -152,6 +192,11 @@ def separate_audio_video(video_with_audio_path: str, basename_without_ext: str, 
     print(f"{ULTRASINGER_HEAD} Extracting audio from video")
     audio_file_path = os.path.join(output_folder, f"{basename_without_ext}.{audio_ext}")
     extract_audio(video_with_audio_path, audio_file_path)
+
+    # Convert to UltraStar-compatible format if needed
+    audio_file_path, audio_ext = convert_to_ultrastar_format(
+        audio_file_path, basename_without_ext, output_folder, audio_ext
+    )
 
     print(f"{ULTRASINGER_HEAD} Creating video without audio")
     video_only_path = os.path.join(output_folder, f"{basename_without_ext}_video.{video_ext}")

--- a/src/modules/ffmpeg_helper.py
+++ b/src/modules/ffmpeg_helper.py
@@ -142,6 +142,7 @@ def convert_to_ultrastar_format(audio_file_path: str, basename_without_ext: str,
     Returns the (possibly updated) audio file path and extension.
     """
     ULTRASTAR_COMPATIBLE_FORMATS = {"mp3", "ogg", "wav"}
+    audio_ext = audio_ext.lstrip(".").lower()
 
     if audio_ext in ULTRASTAR_COMPATIBLE_FORMATS:
         return audio_file_path, audio_ext

--- a/src/modules/init_interactive_mode.py
+++ b/src/modules/init_interactive_mode.py
@@ -140,10 +140,27 @@ def configure_additional_options(console, settings, header):
         if language:  
             settings.language = language  
   
-        # Transcribe Numbers as Numerics  
-        keep_numbers_input = console.input(  
-            f"\n{header} Do you want to transcribe [green]numbers as numerics[/green]? ([bright_green]y[/bright_green]/[bright_red]n[/bright_red], default '[bright_red]n[/bright_red]'): "  
-        ).strip().lower()  
+        # BPM Override
+        if settings.bpm_override is None:
+            bpm_input = console.input(
+                f"\n{header} Enter a manual [green]BPM[/green] value to override auto-detection (leave empty for auto-detect): "
+            ).strip()
+            if bpm_input:
+                try:
+                    bpm_val = float(bpm_input)
+                    if bpm_val > 0:
+                        settings.bpm_override = bpm_val
+                    else:
+                        console.print(f"{header} [bold red]Error:[/bold red] BPM must be positive. Using auto-detection.")
+                except ValueError:
+                    console.print(f"{header} [bold red]Error:[/bold red] Invalid BPM value. Using auto-detection.")
+        else:
+            console.print(f"{header} Using CLI BPM override: [cyan]{settings.bpm_override}[/cyan]")
+
+        # Transcribe Numbers as Numerics
+        keep_numbers_input = console.input(
+            f"\n{header} Do you want to transcribe [green]numbers as numerics[/green]? ([bright_green]y[/bright_green]/[bright_red]n[/bright_red], default '[bright_red]n[/bright_red]'): "
+        ).strip().lower()
         settings.keep_numbers = keep_numbers_input == 'y'  
   
         # MuseScore Path  

--- a/src/modules/init_interactive_mode.py
+++ b/src/modules/init_interactive_mode.py
@@ -121,13 +121,8 @@ def configure_additional_options(console, settings, header):
         # Force Whisper CPU Usage  
         settings.force_whisper_cpu = console.input(  
             f"{header} Force [green]Whisper CPU usage[/green]? ([bright_green]y[/bright_green]/[bright_red]n[/bright_red], default '[bright_red]n[/bright_red]'): "  
-        ).strip().lower() == 'y'  
-  
-        # Force Crepe CPU Usage  
-        settings.force_crepe_cpu = console.input(  
-            f"{header} Force [green]Crepe CPU usage[/green]? ([bright_green]y[/bright_green]/[bright_red]n[/bright_red], default '[bright_red]n[/bright_red]'): "  
-        ).strip().lower() == 'y'  
-  
+        ).strip().lower() == 'y'
+
         # Keep Cache  
         settings.keep_cache = console.input(  
             f"{header} Keep [green]cache[/green] after execution? ([bright_green]y[/bright_green]/[bright_red]n[/bright_red], default '[bright_red]n[/bright_red]'): "  

--- a/src/modules/init_interactive_mode.py
+++ b/src/modules/init_interactive_mode.py
@@ -153,16 +153,12 @@ def configure_additional_options(console, settings, header):
         if musescore_path:  
             settings.musescore_path = musescore_path  
   
-        # Cookie options for YouTube Downloads
-        cookie_method = console.input(
-            f"\n{header} YouTube cookie method: [green]browser[/green] name (e.g. chrome, firefox, edge) "
-            f"or path to [green]cookies.txt[/green] file (leave empty to skip): "
-        ).strip()
-        if cookie_method:
-            if os.path.exists(cookie_method):
-                settings.cookiefile = cookie_method
-            else:
-                settings.cookies_from_browser = cookie_method
+        # Cookie File for YouTube Downloads  
+        cookie_file = console.input(  
+            f"\n{header} Enter the path to [green]cookies.txt[/green] file (if required for YouTube downloads, leave empty otherwise): "  
+        ).strip()  
+        if cookie_file:  
+            settings.cookiefile = cookie_file
 
         # FFmpeg executable path
         ffmpeg_path = console.input(

--- a/src/modules/init_interactive_mode.py
+++ b/src/modules/init_interactive_mode.py
@@ -153,12 +153,16 @@ def configure_additional_options(console, settings, header):
         if musescore_path:  
             settings.musescore_path = musescore_path  
   
-        # Cookie File for YouTube Downloads  
-        cookie_file = console.input(  
-            f"\n{header} Enter the path to [green]cookies.txt[/green] file (if required for YouTube downloads, leave empty otherwise): "  
-        ).strip()  
-        if cookie_file:  
-            settings.cookiefile = cookie_file
+        # Cookie options for YouTube Downloads
+        cookie_method = console.input(
+            f"\n{header} YouTube cookie method: [green]browser[/green] name (e.g. chrome, firefox, edge) "
+            f"or path to [green]cookies.txt[/green] file (leave empty to skip): "
+        ).strip()
+        if cookie_method:
+            if os.path.exists(cookie_method):
+                settings.cookiefile = cookie_method
+            else:
+                settings.cookies_from_browser = cookie_method
 
         # FFmpeg executable path
         ffmpeg_path = console.input(

--- a/src/modules/plot.py
+++ b/src/modules/plot.py
@@ -63,7 +63,7 @@ def plot(
 ) -> None:
     """Plot transcribed data"""
 
-    # determine time between to datapoints if there is no gap (this is the step size crepe ran with)
+    # determine time between two datapoints if there is no gap (pitch detector step size)
     step_size = pitched_data.times[1]
     pitched_data = get_pitched_data_with_high_confidence(pitched_data)
 

--- a/tools/compare_ultrastar.py
+++ b/tools/compare_ultrastar.py
@@ -1,0 +1,569 @@
+"""Compare two UltraStar TXT files and report quality metrics.
+
+Developer tool for evaluating generated UltraStar files against reference files.
+Handles format differences automatically (v1.2.0 pitch convention vs legacy raw MIDI).
+
+Usage:
+    uv run python tools/compare_ultrastar.py generated.txt reference.txt
+    uv run python tools/compare_ultrastar.py generated.txt reference.txt --json
+    uv run python tools/compare_ultrastar.py generated.txt reference.txt --detailed
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import unicodedata
+from dataclasses import dataclass, field
+from difflib import SequenceMatcher
+from pathlib import Path
+from statistics import median, mean
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Note:
+    """A single note parsed from an UltraStar TXT file."""
+    note_type: str          # ':', '*', 'F', 'R', 'G'
+    start_beat: int
+    duration: int
+    pitch: int              # raw pitch value from the file
+    midi: int               # normalised MIDI note number
+    word: str               # lyric text (may be '~' for continuation)
+    start_ms: float         # start time in milliseconds
+    end_ms: float           # end time in milliseconds
+
+
+@dataclass
+class WordGroup:
+    """A word with all its continuation notes grouped together."""
+    word: str               # the displayable word (without '~' suffixes)
+    notes: list[Note] = field(default_factory=list)
+    midi: int = 0           # primary MIDI pitch (first note)
+    start_ms: float = 0.0   # start time of the first note
+    end_ms: float = 0.0     # end time of the last note
+
+
+@dataclass
+class ParsedFile:
+    """Result of parsing an UltraStar TXT file."""
+    path: str
+    version: str | None     # None for legacy files
+    bpm: float              # header BPM value
+    gap: float              # header GAP in milliseconds
+    notes: list[Note] = field(default_factory=list)
+    word_groups: list[WordGroup] = field(default_factory=list)
+    linebreak_count: int = 0
+    headers: dict = field(default_factory=dict)
+
+
+@dataclass
+class ComparisonResult:
+    """Complete comparison metrics."""
+    # Pitch
+    pitch_diffs: list[int] = field(default_factory=list)
+    pitch_median: float = 0.0
+    pitch_mean: float = 0.0
+    pitch_exact_pct: float = 0.0
+    pitch_within_2_pct: float = 0.0
+
+    # Intervals
+    interval_diffs: list[int] = field(default_factory=list)
+    interval_exact_pct: float = 0.0
+    interval_within_2_pct: float = 0.0
+
+    # Timing (ms)
+    timing_diffs: list[float] = field(default_factory=list)
+    timing_median: float = 0.0
+    timing_mean: float = 0.0
+    timing_within_100: float = 0.0
+    timing_within_200: float = 0.0
+    timing_within_500: float = 0.0
+
+    # Lyrics
+    matched_pairs: int = 0
+    gen_word_count: int = 0
+    ref_word_count: int = 0
+    lyrics_precision: float = 0.0
+    lyrics_recall: float = 0.0
+
+    # Structure
+    gen_note_count: int = 0
+    ref_note_count: int = 0
+    gen_linebreaks: int = 0
+    ref_linebreaks: int = 0
+
+    # Meta
+    gen_bpm: float = 0.0
+    ref_bpm: float = 0.0
+    gen_gap: float = 0.0
+    ref_gap: float = 0.0
+    gen_version: str | None = None
+    ref_version: str | None = None
+
+    # Detail (word-level pairs)
+    word_pairs: list[dict] = field(default_factory=list)
+
+    def to_json(self) -> str:
+        """Serialise to JSON string."""
+        d = {
+            "pitch": {
+                "median_diff": self.pitch_median,
+                "mean_diff": self.pitch_mean,
+                "exact_pct": self.pitch_exact_pct,
+                "within_2st_pct": self.pitch_within_2_pct,
+                "count": len(self.pitch_diffs),
+            },
+            "intervals": {
+                "exact_pct": self.interval_exact_pct,
+                "within_2st_pct": self.interval_within_2_pct,
+                "count": len(self.interval_diffs),
+            },
+            "timing": {
+                "median_ms": self.timing_median,
+                "mean_ms": self.timing_mean,
+                "within_100ms_pct": self.timing_within_100,
+                "within_200ms_pct": self.timing_within_200,
+                "within_500ms_pct": self.timing_within_500,
+                "count": len(self.timing_diffs),
+            },
+            "lyrics": {
+                "matched_pairs": self.matched_pairs,
+                "gen_words": self.gen_word_count,
+                "ref_words": self.ref_word_count,
+                "precision": self.lyrics_precision,
+                "recall": self.lyrics_recall,
+            },
+            "structure": {
+                "gen_notes": self.gen_note_count,
+                "ref_notes": self.ref_note_count,
+                "gen_linebreaks": self.gen_linebreaks,
+                "ref_linebreaks": self.ref_linebreaks,
+            },
+            "meta": {
+                "gen_bpm": self.gen_bpm,
+                "ref_bpm": self.ref_bpm,
+                "gen_gap": self.gen_gap,
+                "ref_gap": self.ref_gap,
+                "gen_version": self.gen_version,
+                "ref_version": self.ref_version,
+            },
+        }
+        return json.dumps(d, indent=2)
+
+    def to_summary(self, detailed: bool = False) -> str:
+        """Human-readable summary."""
+        lines: list[str] = []
+        lines.append("=" * 60)
+        lines.append("UltraStar Comparison Report")
+        lines.append("=" * 60)
+
+        lines.append(f"\nFormat: generated={self.gen_version or 'legacy'}"
+                     f"  reference={self.ref_version or 'legacy'}")
+        lines.append(f"BPM:    generated={self.gen_bpm:.2f}"
+                     f"  reference={self.ref_bpm:.2f}")
+        lines.append(f"GAP:    generated={self.gen_gap:.0f}ms"
+                     f"  reference={self.ref_gap:.0f}ms"
+                     f"  (diff={self.gen_gap - self.ref_gap:+.0f}ms)")
+
+        lines.append(f"\n--- Pitch ({len(self.pitch_diffs)} matched words) ---")
+        lines.append(f"  Median offset:  {self.pitch_median:+.1f} semitones")
+        lines.append(f"  Mean offset:    {self.pitch_mean:+.1f} semitones")
+        lines.append(f"  Exact (0 ST):   {self.pitch_exact_pct:.1f}%")
+        lines.append(f"  Within +/-2 ST: {self.pitch_within_2_pct:.1f}%")
+
+        lines.append(f"\n--- Intervals ({len(self.interval_diffs)} consecutive pairs) ---")
+        lines.append(f"  Exact:          {self.interval_exact_pct:.1f}%")
+        lines.append(f"  Within +/-2 ST: {self.interval_within_2_pct:.1f}%")
+
+        lines.append(f"\n--- Timing ({len(self.timing_diffs)} pairs, excl. 1st word) ---")
+        lines.append(f"  Median:         {self.timing_median:+.0f}ms")
+        lines.append(f"  Mean:           {self.timing_mean:+.0f}ms")
+        lines.append(f"  Within 100ms:   {self.timing_within_100:.1f}%")
+        lines.append(f"  Within 200ms:   {self.timing_within_200:.1f}%")
+        lines.append(f"  Within 500ms:   {self.timing_within_500:.1f}%")
+
+        lines.append(f"\n--- Lyrics ---")
+        lines.append(f"  Matched pairs:  {self.matched_pairs}")
+        lines.append(f"  Generated:      {self.gen_word_count} words")
+        lines.append(f"  Reference:      {self.ref_word_count} words")
+        lines.append(f"  Precision:      {self.lyrics_precision:.1f}%")
+        lines.append(f"  Recall:         {self.lyrics_recall:.1f}%")
+
+        lines.append(f"\n--- Structure ---")
+        lines.append(f"  Notes:          {self.gen_note_count} gen"
+                     f" / {self.ref_note_count} ref")
+        lines.append(f"  Linebreaks:     {self.gen_linebreaks} gen"
+                     f" / {self.ref_linebreaks} ref")
+
+        if detailed and self.word_pairs:
+            lines.append(f"\n--- Word-level detail (first 50) ---")
+            lines.append(f"{'Gen Word':<15} {'Ref Word':<15}"
+                         f" {'PitchD':>6} {'TimeD':>8} {'GenMIDI':>7}"
+                         f" {'RefMIDI':>7}")
+            lines.append("-" * 70)
+            for wp in self.word_pairs[:50]:
+                lines.append(
+                    f"{wp['gen_word']:<15} {wp['ref_word']:<15}"
+                    f" {wp['pitch_diff']:>+6d} {wp['timing_diff']:>+8.0f}ms"
+                    f" {wp['gen_midi']:>7d} {wp['ref_midi']:>7d}"
+                )
+
+        lines.append("")
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+def _parse_header_value(line: str) -> str:
+    """Extract the value after the first colon in a header line."""
+    idx = line.index(":")
+    return line[idx + 1:].strip()
+
+
+def _parse_gap(raw: str) -> float:
+    """Parse GAP value (may use comma as decimal separator). Returns ms."""
+    return float(raw.replace(",", "."))
+
+
+def _parse_bpm(raw: str) -> float:
+    """Parse BPM value (may use comma as decimal separator)."""
+    return float(raw.replace(",", "."))
+
+
+def _beat_to_ms(beat: int, bpm_header: float, gap_ms: float) -> float:
+    """Convert a beat position to milliseconds.
+
+    UltraStar BPM in the header is 1/4 of the real BPM.
+    Formula: ms = gap_ms + (beat * 60000) / (bpm_header * 4)
+    """
+    real_bpm = bpm_header * 4
+    if real_bpm == 0:
+        return gap_ms
+    return gap_ms + (beat * 60_000) / real_bpm
+
+
+def _pitch_to_midi(pitch: int, version: str | None) -> int:
+    """Convert a file pitch value to a standard MIDI note number.
+
+    - UltraSinger v1.2.0 format: pitch is relative (0 = C4 = MIDI 48)
+      so midi = pitch + 48
+    - Legacy / standard UltraStar format: pitch IS the MIDI note number
+    """
+    if version is not None and _version_ge(version, "1.2.0"):
+        return pitch + 48
+    return pitch
+
+
+def _version_ge(version: str, threshold: str) -> bool:
+    """Check if *version* >= *threshold* using simple numeric comparison."""
+    def _to_tuple(v: str) -> tuple[int, ...]:
+        return tuple(int(x) for x in v.split("."))
+    try:
+        return _to_tuple(version) >= _to_tuple(threshold)
+    except (ValueError, AttributeError):
+        return False
+
+
+_NOTE_TYPES = {":", "*", "F", "R", "G"}
+
+
+def parse_ultrastar(path: str | Path) -> ParsedFile:
+    """Parse an UltraStar TXT file and return normalised data."""
+    path = Path(path)
+    text = path.read_text(encoding="utf-8", errors="replace")
+
+    headers: dict[str, str] = {}
+    version: str | None = None
+    raw_bpm: str = "0"
+    raw_gap: str = "0"
+    raw_notes: list[tuple[str, int, int, int, str]] = []
+    linebreak_count = 0
+
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+
+        # Header
+        if line.startswith("#"):
+            tag_match = re.match(r"#([A-Z_]+):(.*)", line, re.IGNORECASE)
+            if tag_match:
+                tag = tag_match.group(1).upper()
+                value = tag_match.group(2).strip()
+                headers[tag] = value
+                if tag == "VERSION":
+                    version = value
+                elif tag == "BPM":
+                    raw_bpm = value
+                elif tag == "GAP":
+                    raw_gap = value
+            continue
+
+        # End marker
+        if line.upper() == "E":
+            break
+
+        # Linebreak
+        if line.startswith("-"):
+            linebreak_count += 1
+            continue
+
+        # Note line
+        parts = line.split(None, 4)
+        if len(parts) >= 4 and parts[0] in _NOTE_TYPES:
+            try:
+                note_type = parts[0]
+                start_beat = int(parts[1])
+                duration = int(parts[2])
+                pitch = int(parts[3])
+            except ValueError:
+                continue  # skip malformed note lines gracefully
+            word = parts[4] if len(parts) > 4 else ""
+            raw_notes.append((note_type, start_beat, duration, pitch, word))
+
+    bpm = _parse_bpm(raw_bpm)
+    gap_ms = _parse_gap(raw_gap)
+
+    notes: list[Note] = []
+    for note_type, start_beat, duration, pitch, word in raw_notes:
+        midi = _pitch_to_midi(pitch, version)
+        start_ms = _beat_to_ms(start_beat, bpm, gap_ms)
+        end_ms = _beat_to_ms(start_beat + duration, bpm, gap_ms)
+        notes.append(Note(
+            note_type=note_type,
+            start_beat=start_beat,
+            duration=duration,
+            pitch=pitch,
+            midi=midi,
+            word=word,
+            start_ms=start_ms,
+            end_ms=end_ms,
+        ))
+
+    word_groups = _group_words(notes)
+
+    return ParsedFile(
+        path=str(path),
+        version=version,
+        bpm=bpm,
+        gap=gap_ms,
+        notes=notes,
+        word_groups=word_groups,
+        linebreak_count=linebreak_count,
+        headers=headers,
+    )
+
+
+def _group_words(notes: list[Note]) -> list[WordGroup]:
+    """Group continuation notes (~) with their parent word."""
+    groups: list[WordGroup] = []
+    for note in notes:
+        clean_word = note.word.strip()
+        if clean_word.startswith("~") and groups:
+            # Continuation of previous word
+            groups[-1].notes.append(note)
+            groups[-1].end_ms = note.end_ms
+        else:
+            wg = WordGroup(
+                word=clean_word,
+                notes=[note],
+                midi=note.midi,
+                start_ms=note.start_ms,
+                end_ms=note.end_ms,
+            )
+            groups.append(wg)
+    return groups
+
+
+# ---------------------------------------------------------------------------
+# Word alignment
+# ---------------------------------------------------------------------------
+
+def _normalise_word(word: str) -> str:
+    """Normalise a word for fuzzy matching.
+
+    Applies NFKD Unicode decomposition to convert accented characters
+    (e.g. 'é' → 'e') before stripping non-alphanumeric characters.
+    """
+    # Decompose accented characters and remove combining diacritical marks
+    decomposed = unicodedata.normalize("NFKD", word)
+    stripped = "".join(c for c in decomposed if not unicodedata.combining(c))
+    return re.sub(r"[^a-z0-9]", "", stripped.lower())
+
+
+def align_words(
+    gen_groups: list[WordGroup],
+    ref_groups: list[WordGroup],
+) -> list[tuple[int, int]]:
+    """Align generated word groups to reference word groups.
+
+    Returns list of (gen_index, ref_index) pairs.
+    Uses SequenceMatcher on normalised word sequences for robust matching.
+    """
+    gen_words = [_normalise_word(g.word) for g in gen_groups]
+    ref_words = [_normalise_word(g.word) for g in ref_groups]
+
+    # Filter out empty words
+    gen_valid = [(i, w) for i, w in enumerate(gen_words) if w]
+    ref_valid = [(i, w) for i, w in enumerate(ref_words) if w]
+
+    gen_seq = [w for _, w in gen_valid]
+    ref_seq = [w for _, w in ref_valid]
+
+    matcher = SequenceMatcher(None, gen_seq, ref_seq, autojunk=False)
+    pairs: list[tuple[int, int]] = []
+
+    for block in matcher.get_matching_blocks():
+        for k in range(block.size):
+            gi = gen_valid[block.a + k][0]
+            ri = ref_valid[block.b + k][0]
+            pairs.append((gi, ri))
+
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# Comparison
+# ---------------------------------------------------------------------------
+
+def _pct(count: int, total: int) -> float:
+    """Safe percentage calculation."""
+    return (count / total * 100) if total > 0 else 0.0
+
+
+def compare(gen_path: str | Path, ref_path: str | Path) -> ComparisonResult:
+    """Compare a generated UltraStar file against a reference."""
+    gen = parse_ultrastar(gen_path)
+    ref = parse_ultrastar(ref_path)
+
+    pairs = align_words(gen.word_groups, ref.word_groups)
+
+    result = ComparisonResult()
+
+    # Meta
+    result.gen_bpm = gen.bpm
+    result.ref_bpm = ref.bpm
+    result.gen_gap = gen.gap
+    result.ref_gap = ref.gap
+    result.gen_version = gen.version
+    result.ref_version = ref.version
+
+    # Structure
+    result.gen_note_count = len(gen.notes)
+    result.ref_note_count = len(ref.notes)
+    result.gen_linebreaks = gen.linebreak_count
+    result.ref_linebreaks = ref.linebreak_count
+
+    # Lyrics
+    result.gen_word_count = len(gen.word_groups)
+    result.ref_word_count = len(ref.word_groups)
+    result.matched_pairs = len(pairs)
+    result.lyrics_precision = _pct(len(pairs), len(gen.word_groups))
+    result.lyrics_recall = _pct(len(pairs), len(ref.word_groups))
+
+    if not pairs:
+        return result
+
+    # Pitch & Timing
+    pitch_diffs: list[int] = []
+    timing_diffs: list[float] = []
+    word_pair_details: list[dict] = []
+
+    for idx, (gi, ri) in enumerate(pairs):
+        gw = gen.word_groups[gi]
+        rw = ref.word_groups[ri]
+
+        pd = gw.midi - rw.midi
+        pitch_diffs.append(pd)
+
+        td = gw.start_ms - rw.start_ms
+        # Skip first matched word for timing (GAP offset)
+        if idx > 0:
+            timing_diffs.append(td)
+
+        word_pair_details.append({
+            "gen_word": gw.word,
+            "ref_word": rw.word,
+            "gen_midi": gw.midi,
+            "ref_midi": rw.midi,
+            "pitch_diff": pd,
+            "timing_diff": td,
+        })
+
+    result.pitch_diffs = pitch_diffs
+    result.word_pairs = word_pair_details
+
+    if pitch_diffs:
+        result.pitch_median = float(median(pitch_diffs))
+        result.pitch_mean = mean(pitch_diffs)
+        result.pitch_exact_pct = _pct(
+            sum(1 for d in pitch_diffs if d == 0), len(pitch_diffs))
+        result.pitch_within_2_pct = _pct(
+            sum(1 for d in pitch_diffs if abs(d) <= 2), len(pitch_diffs))
+
+    # Intervals (consecutive matched pairs)
+    interval_diffs: list[int] = []
+    for k in range(len(pairs) - 1):
+        gi1, ri1 = pairs[k]
+        gi2, ri2 = pairs[k + 1]
+        gen_interval = gen.word_groups[gi2].midi - gen.word_groups[gi1].midi
+        ref_interval = ref.word_groups[ri2].midi - ref.word_groups[ri1].midi
+        interval_diffs.append(gen_interval - ref_interval)
+
+    result.interval_diffs = interval_diffs
+    if interval_diffs:
+        result.interval_exact_pct = _pct(
+            sum(1 for d in interval_diffs if d == 0), len(interval_diffs))
+        result.interval_within_2_pct = _pct(
+            sum(1 for d in interval_diffs if abs(d) <= 2),
+            len(interval_diffs))
+
+    # Timing
+    result.timing_diffs = timing_diffs
+    if timing_diffs:
+        result.timing_median = float(median(timing_diffs))
+        result.timing_mean = mean(timing_diffs)
+        result.timing_within_100 = _pct(
+            sum(1 for d in timing_diffs if abs(d) <= 100), len(timing_diffs))
+        result.timing_within_200 = _pct(
+            sum(1 for d in timing_diffs if abs(d) <= 200), len(timing_diffs))
+        result.timing_within_500 = _pct(
+            sum(1 for d in timing_diffs if abs(d) <= 500), len(timing_diffs))
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    """CLI entry point for comparing two UltraStar TXT files."""
+    parser = argparse.ArgumentParser(
+        description="Compare two UltraStar TXT files (generated vs reference)")
+    parser.add_argument("generated", help="Path to generated UltraStar TXT")
+    parser.add_argument("reference", help="Path to reference UltraStar TXT")
+    parser.add_argument("--json", action="store_true",
+                        help="Output as JSON")
+    parser.add_argument("--detailed", action="store_true",
+                        help="Show per-word comparison table")
+    args = parser.parse_args()
+
+    result = compare(args.generated, args.reference)
+
+    if args.json:
+        print(result.to_json())
+    else:
+        print(result.to_summary(detailed=args.detailed))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/compare_ultrastar.py
+++ b/tools/compare_ultrastar.py
@@ -188,21 +188,21 @@ class ComparisonResult:
         lines.append(f"  Within 200ms:   {self.timing_within_200:.1f}%")
         lines.append(f"  Within 500ms:   {self.timing_within_500:.1f}%")
 
-        lines.append(f"\n--- Lyrics ---")
+        lines.append("\n--- Lyrics ---")
         lines.append(f"  Matched pairs:  {self.matched_pairs}")
         lines.append(f"  Generated:      {self.gen_word_count} words")
         lines.append(f"  Reference:      {self.ref_word_count} words")
         lines.append(f"  Precision:      {self.lyrics_precision:.1f}%")
         lines.append(f"  Recall:         {self.lyrics_recall:.1f}%")
 
-        lines.append(f"\n--- Structure ---")
+        lines.append("\n--- Structure ---")
         lines.append(f"  Notes:          {self.gen_note_count} gen"
                      f" / {self.ref_note_count} ref")
         lines.append(f"  Linebreaks:     {self.gen_linebreaks} gen"
                      f" / {self.ref_linebreaks} ref")
 
         if detailed and self.word_pairs:
-            lines.append(f"\n--- Word-level detail (first 50) ---")
+            lines.append("\n--- Word-level detail (first 50) ---")
             lines.append(f"{'Gen Word':<15} {'Ref Word':<15}"
                          f" {'PitchD':>6} {'TimeD':>8} {'GenMIDI':>7}"
                          f" {'RefMIDI':>7}")
@@ -263,11 +263,26 @@ def _pitch_to_midi(pitch: int, version: str | None) -> int:
 
 
 def _version_ge(version: str, threshold: str) -> bool:
-    """Check if *version* >= *threshold* using simple numeric comparison."""
+    """Check if *version* >= *threshold* using simple numeric comparison.
+
+    Handles shorthand versions ("1.2" treated as "1.2.0") and suffixed
+    versions ("1.2.0-beta" extracts 1.2.0).  Pads the shorter tuple with
+    trailing zeros so the comparison is always well-defined.
+    """
     def _to_tuple(v: str) -> tuple[int, ...]:
-        return tuple(int(x) for x in v.split("."))
+        parts = [int(m) for m in re.findall(r"\d+", v.split("-")[0])]
+        if not parts:
+            raise ValueError(f"no numeric components in {v!r}")
+        return tuple(parts)
+
     try:
-        return _to_tuple(version) >= _to_tuple(threshold)
+        v_parts = _to_tuple(version)
+        t_parts = _to_tuple(threshold)
+        # Pad shorter tuple with zeros
+        max_len = max(len(v_parts), len(t_parts))
+        v_padded = v_parts + (0,) * (max_len - len(v_parts))
+        t_padded = t_parts + (0,) * (max_len - len(t_parts))
+        return v_padded >= t_padded
     except (ValueError, AttributeError):
         return False
 
@@ -363,13 +378,20 @@ def parse_ultrastar(path: str | Path) -> ParsedFile:
 
 
 def _group_words(notes: list[Note]) -> list[WordGroup]:
-    """Group continuation notes (~) with their parent word."""
+    """Group continuation notes (~) with their parent word.
+
+    Merges continuation text into the parent word so that split words
+    like ``Hel`` + ``~lo`` produce the group word ``Hello``.
+    """
     groups: list[WordGroup] = []
     for note in notes:
         clean_word = note.word.strip()
         if clean_word.startswith("~") and groups:
-            # Continuation of previous word
+            # Continuation of previous word — merge suffix text
+            suffix = clean_word.lstrip("~")
             groups[-1].notes.append(note)
+            if suffix:
+                groups[-1].word += suffix
             groups[-1].end_ms = note.end_ms
         else:
             wg = WordGroup(
@@ -462,12 +484,14 @@ def compare(gen_path: str | Path, ref_path: str | Path) -> ComparisonResult:
     result.gen_linebreaks = gen.linebreak_count
     result.ref_linebreaks = ref.linebreak_count
 
-    # Lyrics
-    result.gen_word_count = len(gen.word_groups)
-    result.ref_word_count = len(ref.word_groups)
+    # Lyrics — use same non-empty word filter as align_words()
+    gen_valid_words = [g for g in gen.word_groups if _normalise_word(g.word)]
+    ref_valid_words = [g for g in ref.word_groups if _normalise_word(g.word)]
+    result.gen_word_count = len(gen_valid_words)
+    result.ref_word_count = len(ref_valid_words)
     result.matched_pairs = len(pairs)
-    result.lyrics_precision = _pct(len(pairs), len(gen.word_groups))
-    result.lyrics_recall = _pct(len(pairs), len(ref.word_groups))
+    result.lyrics_precision = _pct(len(pairs), len(gen_valid_words))
+    result.lyrics_recall = _pct(len(pairs), len(ref_valid_words))
 
     if not pairs:
         return result

--- a/tools/fix_ultrastar_compatibility.py
+++ b/tools/fix_ultrastar_compatibility.py
@@ -1,0 +1,793 @@
+"""Fix UltraStar song compatibility: audio format conversion and encoding normalization.
+
+Scans a directory tree for UltraStar TXT files and fixes two categories of
+compatibility issues:
+
+1. Audio Format Conversion:
+   UltraStar Play only supports mp3, ogg, and wav. Songs with incompatible
+   audio formats (aac, flac, opus, m4a, wma, etc.) are converted to OGG Vorbis
+   using FFmpeg, and the TXT file references are updated accordingly.
+   Original audio files are preserved (never deleted).
+
+2. Encoding Normalization (--normalize-encoding):
+   TXT files in legacy encodings (CP1252, Latin-1, etc.) are converted to UTF-8
+   for universal compatibility across all UltraStar derivatives (USDX, UltraStar
+   Play, Performous, Vocaluxe). The deprecated #ENCODING: tag is removed.
+
+Usage:
+    uv run python tools/fix_ultrastar_compatibility.py "D:\\UltraStar\\Songs"
+    uv run python tools/fix_ultrastar_compatibility.py "D:\\UltraStar\\Songs" --normalize-encoding
+    uv run python tools/fix_ultrastar_compatibility.py "D:\\UltraStar\\Songs" --normalize-encoding --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Ensure stdout can handle Unicode on Windows
+if sys.stdout and hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+if sys.stderr and hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+COMPATIBLE_FORMATS = {"mp3", "ogg", "wav"}
+
+# Formats that are actually a compatible format with a non-standard extension.
+# These are renamed (not re-encoded) to their real format and the TXT tag updated.
+# Example: .us3 files are renamed .mp3 files used by some older song collections.
+RENAME_TO_COMPATIBLE: dict[str, str] = {"us3": "mp3"}
+
+# UltraStar TXT tags that reference audio files
+AUDIO_TAGS = ("#MP3:", "#AUDIO:", "#VOCALS:", "#INSTRUMENTAL:")
+
+# Tags used to identify a file as UltraStar TXT (at least one must be present)
+IDENTITY_TAGS = ("#TITLE:", "#ARTIST:", "#MP3:", "#AUDIO:")
+
+# Encoding fallback chain for reading UltraStar TXT files.
+# Many older song collections use Windows-1252 or Latin-1 encoding.
+_TXT_ENCODINGS = ("utf-8-sig", "cp1252", "latin-1")
+
+TXT_ENCODING_WRITE = "utf-8"
+
+
+# ---------------------------------------------------------------------------
+# Encoding helpers
+# ---------------------------------------------------------------------------
+
+def _read_txt_lines(path: Path) -> tuple[list[str], str]:
+    """Read a TXT file trying multiple encodings.
+
+    Returns (lines, encoding_used).  The fallback chain is:
+      1. UTF-8 (with BOM)  — modern files
+      2. Windows-1252      — Western European (ö ü ä é è ñ ł etc.)
+      3. Latin-1           — never fails (maps all 256 byte values)
+
+    We detect "bad" UTF-8 decoding by checking for the replacement
+    character U+FFFD which appears when errors="replace" substitutes
+    undecodable bytes.
+
+    The returned encoding distinguishes ``"utf-8-sig"`` (BOM present)
+    from ``"utf-8"`` (no BOM) so that writers can preserve the original
+    byte layout.
+    """
+    raw = path.read_bytes()
+    has_bom = raw.startswith(b"\xef\xbb\xbf")
+
+    for enc in _TXT_ENCODINGS:
+        try:
+            text = raw.decode(enc)
+            # If the codec had to replace bytes we get U+FFFD — try next
+            if "\ufffd" in text and enc != _TXT_ENCODINGS[-1]:
+                continue
+            # Report "utf-8" when no BOM was present, even though the
+            # utf-8-sig codec decoded successfully (it accepts both).
+            if enc == "utf-8-sig" and not has_bom:
+                enc = "utf-8"
+            return text.splitlines(keepends=True), enc
+        except (UnicodeDecodeError, LookupError):
+            continue
+
+    # Should never reach here (latin-1 never raises), but just in case
+    return raw.decode("latin-1").splitlines(keepends=True), "latin-1"
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class AudioFileInfo:
+    """Info about a single audio file referenced in a TXT."""
+    tag: str                # e.g. "#MP3:"
+    filename: str           # e.g. "song.aac"
+    extension: str          # e.g. "aac"
+    full_path: Path         # absolute path to the audio file
+    compatible: bool        # True if extension in COMPATIBLE_FORMATS
+
+
+@dataclass
+class SongInfo:
+    """Parsed metadata from one UltraStar TXT file."""
+    txt_path: Path
+    song_dir: Path
+    artist: str = ""
+    title: str = ""
+    audio_files: list[AudioFileInfo] = field(default_factory=list)
+    file_encoding: str = "utf-8"          # detected encoding of the TXT file
+    has_encoding_tag: bool = False         # True if #ENCODING: tag is present
+
+    @property
+    def display_name(self) -> str:
+        if self.artist and self.title:
+            return f"{self.artist} - {self.title}"
+        if self.title:
+            return self.title
+        return self.txt_path.stem
+
+
+@dataclass
+class FileConversion:
+    """Record of a single file conversion."""
+    tag: str                # e.g. "#MP3:"
+    old_filename: str       # e.g. "song.aac"
+    new_filename: str       # e.g. "song.ogg"
+    old_ext: str            # e.g. "aac"
+
+
+@dataclass
+class ConversionResult:
+    """Result of processing one song."""
+    song_info: SongInfo
+    conversions: list[FileConversion] = field(default_factory=list)
+    status: str = "skipped"         # "converted", "skipped", "error", "already_compatible"
+    error_msg: str | None = None
+    warnings: list[str] = field(default_factory=list)
+    encoding_normalized: bool = False      # True if encoding was converted to UTF-8
+    encoding_from: str | None = None       # original encoding if normalized
+    encoding_tag_removed: bool = False     # True if #ENCODING: tag was removed
+
+
+# ---------------------------------------------------------------------------
+# TXT discovery and parsing
+# ---------------------------------------------------------------------------
+
+def is_ultrastar_txt(path: Path) -> bool:
+    """Check if a file is an UltraStar TXT by looking for identity tags."""
+    try:
+        lines, _ = _read_txt_lines(path)
+        for i, line in enumerate(lines):
+            if i >= 50:
+                break
+            line_upper = line.strip().upper()
+            for tag in IDENTITY_TAGS:
+                if line_upper.startswith(tag):
+                    return True
+    except OSError:
+        pass
+    return False
+
+
+def find_ultrastar_txts(root: Path) -> list[Path]:
+    """Recursively find all UltraStar TXT files under root."""
+    txts = []
+    for path in sorted(root.rglob("*.txt")):
+        if path.is_file() and is_ultrastar_txt(path):
+            txts.append(path)
+    return txts
+
+
+def parse_song_info(txt_path: Path) -> SongInfo | None:
+    """Parse audio tags and metadata from an UltraStar TXT file."""
+    song_dir = txt_path.parent
+    info = SongInfo(txt_path=txt_path, song_dir=song_dir)
+
+    try:
+        lines, detected_enc = _read_txt_lines(txt_path)
+    except OSError as e:
+        print(f"  WARNING: Cannot read {txt_path}: {e}", file=sys.stderr)
+        return None
+
+    info.file_encoding = detected_enc
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped.startswith("#"):
+            continue
+
+        # Extract tag and value — split only on first ':'
+        colon_idx = stripped.find(":")
+        if colon_idx < 0:
+            continue
+
+        tag_part = stripped[: colon_idx + 1].upper()  # e.g. "#MP3:"
+        value = stripped[colon_idx + 1:].strip()
+
+        if tag_part == "#ENCODING:":
+            info.has_encoding_tag = True
+
+        if not value:
+            continue
+
+        if tag_part == "#ARTIST:":
+            info.artist = value
+        elif tag_part == "#TITLE:":
+            info.title = value
+        elif tag_part in ("#MP3:", "#AUDIO:", "#VOCALS:", "#INSTRUMENTAL:"):
+            ext = _get_extension(value)
+            resolved = _resolve_audio_file(song_dir, value)
+            full_path = resolved if resolved is not None else song_dir / value
+            # Reject paths that escape the song directory (path traversal)
+            try:
+                full_path.resolve().relative_to(song_dir.resolve())
+            except ValueError:
+                continue
+            info.audio_files.append(AudioFileInfo(
+                tag=tag_part,
+                filename=value,
+                extension=ext,
+                full_path=full_path,
+                compatible=ext in COMPATIBLE_FORMATS,
+            ))
+
+    return info
+
+
+def _get_extension(filename: str) -> str:
+    """Extract lowercase extension without dot from a filename."""
+    _, ext = os.path.splitext(filename)
+    return ext.lstrip(".").lower()
+
+
+def _resolve_audio_file(song_dir: Path, filename: str) -> Path | None:
+    """Find the actual audio file on disk, handling encoding mismatches.
+
+    UltraStar TXT files may be encoded differently from the filesystem,
+    causing the parsed filename to not match the actual file on disk.
+    For example: TXT in CP1252 references ``byłam`` (byte 0xB3) but the
+    file on disk is named ``byêam`` (UTF-8).
+
+    Strategy:
+      1. Try exact match first (fast path).
+      2. Try case-insensitive match against directory listing.
+      3. If there's exactly one file with the same extension, use that.
+      4. Otherwise return None (truly missing).
+    """
+    exact = song_dir / filename
+    if exact.is_file():
+        return exact
+
+    # List files in song directory once
+    try:
+        dir_files = list(song_dir.iterdir())
+    except OSError:
+        return None
+
+    ext = _get_extension(filename).lower()
+    target_lower = filename.lower()
+
+    # Case-insensitive match
+    for f in dir_files:
+        if f.is_file() and f.name.lower() == target_lower:
+            return f
+
+    # Extension-based fallback: if exactly one file has the same extension, use it
+    same_ext = [f for f in dir_files if f.is_file() and _get_extension(f.name) == ext]
+    if len(same_ext) == 1:
+        return same_ext[0]
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# FFmpeg conversion
+# ---------------------------------------------------------------------------
+
+def check_ffmpeg() -> str:
+    """Return the ffmpeg executable path or raise if not found."""
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg:
+        print("ERROR: ffmpeg not found in PATH. Please install FFmpeg.", file=sys.stderr)
+        sys.exit(1)
+    return ffmpeg
+
+
+def convert_to_ogg(ffmpeg_path: str, input_path: Path, output_path: Path) -> None:
+    """Convert an audio file to OGG Vorbis using FFmpeg."""
+    cmd = [
+        ffmpeg_path,
+        "-i", str(input_path),
+        "-y",
+        "-vn",                     # Discard video streams (e.g. from .mp4)
+        "-loglevel", "error",
+        "-codec:a", "libvorbis",
+        "-q:a", "6",               # High quality VBR (~192 kbps)
+        str(output_path),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"FFmpeg conversion failed: {result.stderr.strip()}")
+
+
+# ---------------------------------------------------------------------------
+# TXT file update
+# ---------------------------------------------------------------------------
+
+def update_txt_tags(txt_path: Path, replacements: dict[str, str]) -> None:
+    """Replace audio filenames in TXT tags.
+
+    Reads the file with encoding auto-detection and writes back in the
+    *same* encoding to avoid silently changing the file encoding when
+    only an audio tag update is needed (i.e. without --normalize-encoding).
+
+    Args:
+        txt_path: Path to the UltraStar TXT file.
+        replacements: Mapping of old_filename → new_filename.
+    """
+    lines, detected_enc = _read_txt_lines(txt_path)
+
+    updated = False
+    new_lines = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            colon_idx = stripped.find(":")
+            if colon_idx >= 0:
+                tag_part = stripped[: colon_idx + 1].upper()
+                value = stripped[colon_idx + 1:].strip()
+                if tag_part in ("#MP3:", "#AUDIO:", "#VOCALS:", "#INSTRUMENTAL:"):
+                    if value in replacements:
+                        # Preserve original tag case from the file
+                        original_tag = stripped[: colon_idx + 1]
+                        line = f"{original_tag}{replacements[value]}\n"
+                        updated = True
+        new_lines.append(line)
+
+    if updated:
+        # Preserve original encoding — use detected encoding, not UTF-8
+        write_enc = detected_enc if detected_enc != "utf-8-sig" else "utf-8-sig"
+        with open(txt_path, "w", encoding=write_enc, newline="") as f:
+            f.writelines(new_lines)
+
+
+# ---------------------------------------------------------------------------
+# Encoding normalization
+# ---------------------------------------------------------------------------
+
+def _is_utf8_no_bom(enc: str) -> bool:
+    """Check if an encoding is plain UTF-8 (without BOM).
+
+    Returns False for ``"utf-8-sig"`` because the BOM should be stripped
+    during normalization — UTF-8 without BOM is the universal encoding
+    supported by all UltraStar derivatives (USDX, UltraStar Play,
+    Performous, Vocaluxe).
+    """
+    return enc.lower().replace("-", "").replace("_", "") == "utf8"
+
+
+def normalize_txt_encoding(txt_path: Path) -> tuple[bool, bool]:
+    """Re-encode a TXT file to UTF-8 and remove the deprecated #ENCODING: tag.
+
+    Returns (encoding_changed, encoding_tag_removed).
+    """
+    lines, detected_enc = _read_txt_lines(txt_path)
+
+    encoding_changed = not _is_utf8_no_bom(detected_enc)
+    encoding_tag_removed = False
+
+    # Filter out #ENCODING: lines (deprecated since format v1.0.0)
+    new_lines = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            colon_idx = stripped.find(":")
+            if colon_idx >= 0:
+                tag_part = stripped[: colon_idx + 1].upper()
+                if tag_part == "#ENCODING:":
+                    encoding_tag_removed = True
+                    continue  # skip this line
+        new_lines.append(line)
+
+    # Only write if something actually changed
+    if encoding_changed or encoding_tag_removed:
+        with open(txt_path, "w", encoding=TXT_ENCODING_WRITE, newline="") as f:
+            f.writelines(new_lines)
+
+    return encoding_changed, encoding_tag_removed
+
+
+# ---------------------------------------------------------------------------
+# Song processing
+# ---------------------------------------------------------------------------
+
+def process_song(
+    song_info: SongInfo,
+    ffmpeg_path: str | None,
+    dry_run: bool,
+    normalize_encoding: bool = False,
+) -> ConversionResult:
+    """Process a single song: check audio compatibility and convert if needed.
+
+    If normalize_encoding is True, also re-encode non-UTF-8 TXT files to UTF-8
+    and remove the deprecated #ENCODING: tag.
+    """
+    result = ConversionResult(song_info=song_info)
+
+    # --- Encoding normalization ---
+    needs_encoding_fix = normalize_encoding and (
+        not _is_utf8_no_bom(song_info.file_encoding)
+        or song_info.has_encoding_tag
+    )
+
+    if needs_encoding_fix:
+        if not _is_utf8_no_bom(song_info.file_encoding):
+            result.encoding_normalized = True
+            result.encoding_from = song_info.file_encoding
+        if song_info.has_encoding_tag:
+            result.encoding_tag_removed = True
+
+        if not dry_run:
+            try:
+                normalize_txt_encoding(song_info.txt_path)
+            except Exception as e:
+                result.warnings.append(f"Encoding normalization failed: {e}")
+                result.encoding_normalized = False
+                result.encoding_tag_removed = False
+
+    # --- Audio format conversion ---
+    if not song_info.audio_files:
+        if needs_encoding_fix:
+            # No audio tags but encoding was fixed — that's still a useful result
+            result.status = "already_compatible"
+        else:
+            result.status = "error"
+            result.error_msg = "No audio tags found in TXT"
+        return result
+
+    # Check which files need conversion
+    needs_conversion: list[AudioFileInfo] = []
+    has_missing = False
+    for af in song_info.audio_files:
+        if af.compatible:
+            continue
+
+        # Check if audio file exists
+        if not af.full_path.is_file():
+            result.warnings.append(f"{af.tag} {af.filename} — file not found, skipping")
+            has_missing = True
+            continue
+
+        needs_conversion.append(af)
+
+    if not needs_conversion:
+        # Distinguish: all compatible vs. all missing
+        if has_missing:
+            result.status = "error"
+            result.error_msg = "Incompatible audio file(s) not found on disk"
+        else:
+            result.status = "already_compatible"
+        return result
+
+    # Build replacements: group by actual file (multiple tags may reference the same file)
+    file_replacements: dict[str, str] = {}  # old_filename → new_filename
+    renames_to_do: list[tuple[AudioFileInfo, Path]] = []     # just rename (e.g. .us3 → .mp3)
+    conversions_to_do: list[tuple[AudioFileInfo, Path]] = []  # FFmpeg conversion → .ogg
+
+    for af in needs_conversion:
+        if af.filename in file_replacements:
+            # Already planned (another tag references the same file)
+            new_filename = file_replacements[af.filename]
+            result.conversions.append(FileConversion(
+                tag=af.tag,
+                old_filename=af.filename,
+                new_filename=new_filename,
+                old_ext=af.extension,
+            ))
+            continue
+
+        stem = af.full_path.stem
+
+        # Preserve any subdirectory prefix from the original tag value.
+        # E.g. if filename is "audio/song.flac", prefix is "audio/" and
+        # the replacement must be "audio/song.ogg", not just "song.ogg".
+        dir_part = os.path.dirname(af.filename)
+        prefix = f"{dir_part}/" if dir_part else ""
+
+        # Check if this is a renamed compatible format (e.g. .us3 = .mp3)
+        real_ext = RENAME_TO_COMPATIBLE.get(af.extension)
+        if real_ext:
+            new_basename = f"{stem}.{real_ext}"
+            new_path = af.full_path.parent / new_basename
+            renames_to_do.append((af, new_path))
+        else:
+            new_basename = f"{stem}.ogg"
+            new_path = af.full_path.parent / new_basename
+            conversions_to_do.append((af, new_path))
+
+        new_filename = f"{prefix}{new_basename}"
+        file_replacements[af.filename] = new_filename
+
+        result.conversions.append(FileConversion(
+            tag=af.tag,
+            old_filename=af.filename,
+            new_filename=new_filename,
+            old_ext=af.extension,
+        ))
+
+    if dry_run:
+        result.status = "converted"  # would be converted
+        return result
+
+    try:
+        # Perform FFmpeg conversions first — resolve ffmpeg lazily on first need
+        for af, ogg_path in conversions_to_do:
+            if ogg_path.is_file():
+                # OGG already exists (previous run?) — skip conversion but still update TXT
+                result.warnings.append(
+                    f"{ogg_path.name} already exists, skipping conversion"
+                )
+            else:
+                if ffmpeg_path is None:
+                    ffmpeg_path = check_ffmpeg()
+                convert_to_ogg(ffmpeg_path, af.full_path, ogg_path)
+
+        # Update TXT file with new filenames — before renames so that on
+        # failure the original filenames still match the files on disk.
+        update_txt_tags(song_info.txt_path, file_replacements)
+
+        # Perform renames last (no re-encoding needed).  Done after TXT
+        # update so the TXT already points to the new name if this step
+        # fails partially.
+        for af, new_path in renames_to_do:
+            if new_path.is_file():
+                result.warnings.append(
+                    f"{new_path.name} already exists, skipping rename"
+                )
+            else:
+                af.full_path.rename(new_path)
+
+        result.status = "converted"
+
+    except Exception as e:
+        result.status = "error"
+        result.error_msg = str(e)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Statistics output
+# ---------------------------------------------------------------------------
+
+def print_summary(
+    results: list[ConversionResult],
+    dry_run: bool,
+    normalize_encoding: bool = False,
+) -> None:
+    """Print conversion summary statistics."""
+    total = len(results)
+    compatible = sum(1 for r in results if r.status == "already_compatible")
+    converted = sum(1 for r in results if r.status == "converted")
+    errors = sum(1 for r in results if r.status == "error")
+    skipped = sum(1 for r in results if r.status == "skipped")
+
+    enc_normalized = sum(1 for r in results if r.encoding_normalized)
+    enc_tag_removed = sum(1 for r in results if r.encoding_tag_removed)
+
+    print()
+    if dry_run:
+        print("=" * 55)
+        print("  DRY RUN — No changes were made")
+        print("=" * 55)
+    else:
+        print("=" * 55)
+        print("  Conversion Summary")
+        print("=" * 55)
+
+    print(f"  Songs scanned:          {total:>5}")
+    print(f"  Already compatible:     {compatible:>5}")
+    if dry_run:
+        print(f"  Audio would convert:    {converted:>5}")
+    else:
+        print(f"  Audio converted:        {converted:>5}")
+    if errors:
+        print(f"  Errors:                 {errors:>5}")
+    if skipped:
+        print(f"  Skipped (no audio):     {skipped:>5}")
+
+    if normalize_encoding:
+        print("  " + "-" * 40)
+        if dry_run:
+            print(f"  Encoding would fix:     {enc_normalized:>5}")
+            if enc_tag_removed:
+                print(f"  #ENCODING: would drop:  {enc_tag_removed:>5}")
+        else:
+            print(f"  Encoding normalized:    {enc_normalized:>5}")
+            if enc_tag_removed:
+                print(f"  #ENCODING: removed:     {enc_tag_removed:>5}")
+
+        # Show encoding distribution
+        enc_counts: dict[str, int] = {}
+        for r in results:
+            enc = r.song_info.file_encoding
+            enc_counts[enc] = enc_counts.get(enc, 0) + 1
+        if enc_counts:
+            print("  " + "-" * 40)
+            print("  Encoding distribution:")
+            for enc_name in sorted(enc_counts, key=lambda e: -enc_counts[e]):
+                count = enc_counts[enc_name]
+                marker = "" if _is_utf8_no_bom(enc_name) else " ←"
+                print(f"    {enc_name:<15} {count:>5}{marker}")
+
+    print("=" * 55)
+
+    # Print warnings
+    for r in results:
+        for w in r.warnings:
+            print(f"  WARNING: [{r.song_info.display_name}] {w}")
+            print(f"           {r.song_info.song_dir}")
+
+    # Print errors
+    for r in results:
+        if r.status == "error":
+            print(f"  ERROR:   [{r.song_info.display_name}] {r.error_msg}")
+            print(f"           {r.song_info.song_dir}")
+
+
+def print_song_list(
+    results: list[ConversionResult],
+    dry_run: bool,
+    normalize_encoding: bool = False,
+) -> None:
+    """Print the list of converted (or would-be-converted) songs."""
+    # Audio conversions
+    converted = [r for r in results if r.status == "converted"]
+    if converted:
+        print()
+        if dry_run:
+            print(f"=== Songs that would be converted ({len(converted)}) ===")
+        else:
+            print(f"=== Converted songs ({len(converted)}) ===")
+
+        for i, r in enumerate(converted, 1):
+            print(f"  [{i:>3}] {r.song_info.display_name}")
+            for c in r.conversions:
+                rename = c.old_ext in RENAME_TO_COMPATIBLE
+                label = "rename" if rename else "convert"
+                print(f"        {c.tag[1:]} {c.old_filename} \u2192 {c.new_filename} ({label})")
+
+        print()
+
+    # Encoding normalizations (only when --normalize-encoding is active)
+    if normalize_encoding:
+        enc_fixed = [r for r in results
+                     if r.encoding_normalized or r.encoding_tag_removed]
+        if enc_fixed:
+            print()
+            if dry_run:
+                print(f"=== Songs with encoding to normalize ({len(enc_fixed)}) ===")
+            else:
+                print(f"=== Songs with encoding normalized ({len(enc_fixed)}) ===")
+
+            for i, r in enumerate(enc_fixed, 1):
+                extra = ""
+                if r.encoding_tag_removed:
+                    extra = " + #ENCODING: removed"
+                enc_label = r.encoding_from or "utf-8"
+                print(
+                    f"  [{i:>3}] {r.song_info.display_name}"
+                    f"  ({enc_label} \u2192 utf-8{extra})"
+                )
+
+            print()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="fix_ultrastar_compatibility",
+        description=(
+            "Fix UltraStar song compatibility: convert incompatible audio formats "
+            "to OGG Vorbis and optionally normalize TXT file encoding to UTF-8."
+        ),
+        epilog=(
+            "UltraStar Play supports mp3, ogg, and wav. "
+            "Other formats (aac, flac, opus, m4a, wma, ...) are converted to OGG Vorbis. "
+            "Original audio files are never deleted. "
+            "Use --normalize-encoding to also convert legacy text encodings "
+            "(CP1252, Latin-1, etc.) to UTF-8 for universal compatibility."
+        ),
+    )
+    parser.add_argument(
+        "directory",
+        type=Path,
+        help="Root directory containing UltraStar song folders",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Only show what would be changed, without making any modifications",
+    )
+    parser.add_argument(
+        "--normalize-encoding",
+        action="store_true",
+        help=(
+            "Convert non-UTF-8 TXT files to UTF-8 and remove deprecated "
+            "#ENCODING: tags. UTF-8 is supported by all UltraStar derivatives."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    root = args.directory.resolve()
+
+    if not root.is_dir():
+        print(f"ERROR: Directory not found: {root}", file=sys.stderr)
+        return 1
+
+    # FFmpeg is resolved lazily — only checked when a real conversion is needed.
+    # This allows --dry-run and --normalize-encoding to work without FFmpeg.
+    ffmpeg_path: str | None = None
+
+    mode_parts = []
+    if args.dry_run:
+        mode_parts.append("DRY RUN")
+    if args.normalize_encoding:
+        mode_parts.append("encoding normalization enabled")
+    prefix = f"[{', '.join(mode_parts)}] " if mode_parts else ""
+    print(f"{prefix}Scanning {root} ...")
+
+    # Discover UltraStar TXT files
+    txt_files = find_ultrastar_txts(root)
+    if not txt_files:
+        print("No UltraStar TXT files found.")
+        return 0
+
+    print(f"Found {len(txt_files)} UltraStar TXT file(s).")
+
+    # Parse and process each song
+    results: list[ConversionResult] = []
+    for txt_path in txt_files:
+        song_info = parse_song_info(txt_path)
+        if song_info is None:
+            continue
+        result = process_song(
+            song_info, ffmpeg_path, args.dry_run,
+            normalize_encoding=args.normalize_encoding,
+        )
+        results.append(result)
+
+        # Progress indicator for conversions
+        if not args.dry_run:
+            if result.status == "converted":
+                print(f"  Audio converted: {result.song_info.display_name}")
+            if result.encoding_normalized:
+                print(
+                    f"  Encoding fixed:  {result.song_info.display_name}"
+                    f"  ({result.encoding_from} → utf-8)"
+                )
+
+    # Output statistics
+    print_summary(results, args.dry_run, args.normalize_encoding)
+    print_song_list(results, args.dry_run, args.normalize_encoding)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/fix_ultrastar_compatibility.py
+++ b/tools/fix_ultrastar_compatibility.py
@@ -73,9 +73,8 @@ def _read_txt_lines(path: Path) -> tuple[list[str], str]:
       2. Windows-1252      — Western European (ö ü ä é è ñ ł etc.)
       3. Latin-1           — never fails (maps all 256 byte values)
 
-    We detect "bad" UTF-8 decoding by checking for the replacement
-    character U+FFFD which appears when errors="replace" substitutes
-    undecodable bytes.
+    Decoding uses strict mode: invalid bytes raise ``UnicodeDecodeError``
+    which triggers the next fallback encoding automatically.
 
     The returned encoding distinguishes ``"utf-8-sig"`` (BOM present)
     from ``"utf-8"`` (no BOM) so that writers can preserve the original
@@ -87,9 +86,6 @@ def _read_txt_lines(path: Path) -> tuple[list[str], str]:
     for enc in _TXT_ENCODINGS:
         try:
             text = raw.decode(enc)
-            # If the codec had to replace bytes we get U+FFFD — try next
-            if "\ufffd" in text and enc != _TXT_ENCODINGS[-1]:
-                continue
             # Report "utf-8" when no BOM was present, even though the
             # utf-8-sig codec decoded successfully (it accepts both).
             if enc == "utf-8-sig" and not has_bom:

--- a/uv.lock
+++ b/uv.lock
@@ -4,10 +4,14 @@ requires-python = ">=3.12, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'win32'",
     "python_full_version >= '3.13' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "(python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version < '3.13' and sys_platform == 'win32'",
     "python_full_version < '3.13' and sys_platform == 'emscripten'",
-    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "(python_full_version < '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.13' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
+    "python_full_version < '3.13' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version < '3.13' and sys_platform == 'darwin'",
 ]
 
 [[package]]
@@ -118,7 +122,8 @@ version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
-    { name = "torch" },
+    { name = "torch", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/90/fa/5c2be1f96dc179f83cdd3bb267edbd1f47d08f756785c016d5c2163901a7/asteroid-filterbanks-0.4.0.tar.gz", hash = "sha256:415f89d1dcf2b13b35f03f7a9370968ac4e6fa6800633c522dac992b283409b9", size = 24599, upload-time = "2021-04-09T20:03:07.456Z" }
@@ -228,7 +233,7 @@ wheels = [
 
 [[package]]
 name = "black"
-version = "26.1.0"
+version = "26.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -238,19 +243,19 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pytokens" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/13/88/560b11e521c522440af991d46848a2bde64b5f7202ec14e1f46f9509d328/black-26.1.0.tar.gz", hash = "sha256:d294ac3340eef9c9eb5d29288e96dc719ff269a88e27b396340459dd85da4c58", size = 658785, upload-time = "2026-01-18T04:50:11.993Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/c5/61175d618685d42b005847464b8fb4743a67b1b8fdb75e50e5a96c31a27a/black-26.3.1.tar.gz", hash = "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07", size = 666155, upload-time = "2026-03-12T03:36:03.593Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/13/710298938a61f0f54cdb4d1c0baeb672c01ff0358712eddaf29f76d32a0b/black-26.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6eeca41e70b5f5c84f2f913af857cf2ce17410847e1d54642e658e078da6544f", size = 1878189, upload-time = "2026-01-18T04:59:30.682Z" },
-    { url = "https://files.pythonhosted.org/packages/79/a6/5179beaa57e5dbd2ec9f1c64016214057b4265647c62125aa6aeffb05392/black-26.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:dd39eef053e58e60204f2cdf059e2442e2eb08f15989eefe259870f89614c8b6", size = 1700178, upload-time = "2026-01-18T04:59:32.387Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/04/c96f79d7b93e8f09d9298b333ca0d31cd9b2ee6c46c274fd0f531de9dc61/black-26.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9459ad0d6cd483eacad4c6566b0f8e42af5e8b583cee917d90ffaa3778420a0a", size = 1777029, upload-time = "2026-01-18T04:59:33.767Z" },
-    { url = "https://files.pythonhosted.org/packages/49/f9/71c161c4c7aa18bdda3776b66ac2dc07aed62053c7c0ff8bbda8c2624fe2/black-26.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:a19915ec61f3a8746e8b10adbac4a577c6ba9851fa4a9e9fbfbcf319887a5791", size = 1406466, upload-time = "2026-01-18T04:59:35.177Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/8b/a7b0f974e473b159d0ac1b6bcefffeb6bec465898a516ee5cc989503cbc7/black-26.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:643d27fb5facc167c0b1b59d0315f2674a6e950341aed0fc05cf307d22bf4954", size = 1216393, upload-time = "2026-01-18T04:59:37.18Z" },
-    { url = "https://files.pythonhosted.org/packages/79/04/fa2f4784f7237279332aa735cdfd5ae2e7730db0072fb2041dadda9ae551/black-26.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ba1d768fbfb6930fc93b0ecc32a43d8861ded16f47a40f14afa9bb04ab93d304", size = 1877781, upload-time = "2026-01-18T04:59:39.054Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/ad/5a131b01acc0e5336740a039628c0ab69d60cf09a2c87a4ec49f5826acda/black-26.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2b807c240b64609cb0e80d2200a35b23c7df82259f80bef1b2c96eb422b4aac9", size = 1699670, upload-time = "2026-01-18T04:59:41.005Z" },
-    { url = "https://files.pythonhosted.org/packages/da/7c/b05f22964316a52ab6b4265bcd52c0ad2c30d7ca6bd3d0637e438fc32d6e/black-26.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1de0f7d01cc894066a1153b738145b194414cc6eeaad8ef4397ac9abacf40f6b", size = 1775212, upload-time = "2026-01-18T04:59:42.545Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/a3/e8d1526bea0446e040193185353920a9506eab60a7d8beb062029129c7d2/black-26.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:91a68ae46bf07868963671e4d05611b179c2313301bd756a89ad4e3b3db2325b", size = 1409953, upload-time = "2026-01-18T04:59:44.357Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/5a/d62ebf4d8f5e3a1daa54adaab94c107b57be1b1a2f115a0249b41931e188/black-26.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:be5e2fe860b9bd9edbf676d5b60a9282994c03fbbd40fe8f5e75d194f96064ca", size = 1217707, upload-time = "2026-01-18T04:59:45.719Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/3d/51bdb3ecbfadfaf825ec0c75e1de6077422b4afa2091c6c9ba34fbfc0c2d/black-26.1.0-py3-none-any.whl", hash = "sha256:1054e8e47ebd686e078c0bb0eaf31e6ce69c966058d122f2c0c950311f9f3ede", size = 204010, upload-time = "2026-01-18T04:50:09.978Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/f8/da5eae4fc75e78e6dceb60624e1b9662ab00d6b452996046dfa9b8a6025b/black-26.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e6f89631eb88a7302d416594a32faeee9fb8fb848290da9d0a5f2903519fc1", size = 1895920, upload-time = "2026-03-12T03:40:13.921Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/9f/04e6f26534da2e1629b2b48255c264cabf5eedc5141d04516d9d68a24111/black-26.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41cd2012d35b47d589cb8a16faf8a32ef7a336f56356babd9fcf70939ad1897f", size = 1718499, upload-time = "2026-03-12T03:40:15.239Z" },
+    { url = "https://files.pythonhosted.org/packages/04/91/a5935b2a63e31b331060c4a9fdb5a6c725840858c599032a6f3aac94055f/black-26.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f76ff19ec5297dd8e66eb64deda23631e642c9393ab592826fd4bdc97a4bce7", size = 1794994, upload-time = "2026-03-12T03:40:17.124Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/0a/86e462cdd311a3c2a8ece708d22aba17d0b2a0d5348ca34b40cdcbea512e/black-26.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:ddb113db38838eb9f043623ba274cfaf7d51d5b0c22ecb30afe58b1bb8322983", size = 1420867, upload-time = "2026-03-12T03:40:18.83Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e5/22515a19cb7eaee3440325a6b0d95d2c0e88dd180cb011b12ae488e031d1/black-26.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:dfdd51fc3e64ea4f35873d1b3fb25326773d55d2329ff8449139ebaad7357efb", size = 1230124, upload-time = "2026-03-12T03:40:20.425Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/77/5728052a3c0450c53d9bb3945c4c46b91baa62b2cafab6801411b6271e45/black-26.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:855822d90f884905362f602880ed8b5df1b7e3ee7d0db2502d4388a954cc8c54", size = 1895034, upload-time = "2026-03-12T03:40:21.813Z" },
+    { url = "https://files.pythonhosted.org/packages/52/73/7cae55fdfdfbe9d19e9a8d25d145018965fe2079fa908101c3733b0c55a0/black-26.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8a33d657f3276328ce00e4d37fe70361e1ec7614da5d7b6e78de5426cb56332f", size = 1718503, upload-time = "2026-03-12T03:40:23.666Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/87/af89ad449e8254fdbc74654e6467e3c9381b61472cc532ee350d28cfdafb/black-26.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f1cd08e99d2f9317292a311dfe578fd2a24b15dbce97792f9c4d752275c1fa56", size = 1793557, upload-time = "2026-03-12T03:40:25.497Z" },
+    { url = "https://files.pythonhosted.org/packages/43/10/d6c06a791d8124b843bf325ab4ac7d2f5b98731dff84d6064eafd687ded1/black-26.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:c7e72339f841b5a237ff14f7d3880ddd0fc7f98a1199e8c4327f9a4f478c1839", size = 1422766, upload-time = "2026-03-12T03:40:27.14Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4f/40a582c015f2d841ac24fed6390bd68f0fc896069ff3a886317959c9daf8/black-26.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc622538b430aa4c8c853f7f63bc582b3b8030fd8c80b70fb5fa5b834e575c2", size = 1232140, upload-time = "2026-03-12T03:40:28.882Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/0d/52d98722666d6fc6c3dd4c76df339501d6efd40e0ff95e6186a7b7f0befd/black-26.3.1-py3-none-any.whl", hash = "sha256:2bd5aa94fc267d38bb21a70d7410a89f1a1d318841855f698746f8e7f51acd1b", size = 207542, upload-time = "2026-03-12T03:36:01.668Z" },
 ]
 
 [[package]]
@@ -299,11 +304,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.1.4"
+version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
 ]
 
 [[package]]
@@ -343,52 +348,62 @@ wheels = [
 
 [[package]]
 name = "chardet"
-version = "6.0.0.post1"
+version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7f/42/fb9436c103a881a377e34b9f58d77b5f503461c702ff654ebe86151bcfe9/chardet-6.0.0.post1.tar.gz", hash = "sha256:6b78048c3c97c7b2ed1fbad7a18f76f5a6547f7d34dbab536cc13887c9a92fa4", size = 12521798, upload-time = "2026-02-22T15:09:17.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/84/e72ea5c06e687db591283474b8442ab95665fc6bae7b06043b2a6f0eaf6c/chardet-7.1.0.tar.gz", hash = "sha256:8f47bc4accac17bd9accbb4acc1d563acc024a783806c0a43c3a583f5285690b", size = 505743, upload-time = "2026-03-11T21:39:37.603Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/42/5de54f632c2de53cd3415b3703383d5fff43a94cbc0567ef362515261a21/chardet-6.0.0.post1-py3-none-any.whl", hash = "sha256:c894a36800549adf7bb5f2af47033281b75fdfcd2aa0f0243be0ad22a52e2dcb", size = 627245, upload-time = "2026-02-22T15:09:15.876Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b8/415efba024c5d6a3d81609de51598a11a99b9f2ffb916c42b72190da1973/chardet-7.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:43c1e3cba6c41d8958ee4acdab94c151dbe256d7ef8df4ae032dc62a892f294f", size = 542358, upload-time = "2026-03-11T21:39:11.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/d7/9517de8b58b487d5d05e957efacc8c9af180cb2cc97103b1a1c67120d8c0/chardet-7.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1a3c22672c9502af99e0433b47421d0d72c8803efce2cd4a91a3ae1ab5972243", size = 534566, upload-time = "2026-03-11T21:39:12.462Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/33/1286f2a05935a80eaadcc13fc70fb0eaa00805acc756363f0f4aca2ed936/chardet-7.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fdfc42dfc44ccd569b84fe6a1fdea1df66dc0c48461bc3899dea5efea8d507f6", size = 556240, upload-time = "2026-03-11T21:39:14.388Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/cc/556aeffb4768b258cc461bc1063d3592e411e1744223da8c7fbbf524438e/chardet-7.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e096d9c211050fff40e22748e1d09d0cec8348fc13ee6e2e0a1da079345b8a86", size = 559737, upload-time = "2026-03-11T21:39:16.382Z" },
+    { url = "https://files.pythonhosted.org/packages/af/4a/147151940ad5ac8bf9f8728a1e46bc63502cd95e93c3a9796f01914188f9/chardet-7.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:a6492bebaba8882afb3e14c786fb69ed767326b6f514b8e093dcdf6e2a094d33", size = 526574, upload-time = "2026-03-11T21:39:18.311Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/79/2c61f33c87d3698f15ca01b0882fbd2fcb95911a783cc615d31adfae025a/chardet-7.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:cc8c7520a9736da766f5794bbabb1c6cdfe446676429a5cf691af878631a80bf", size = 542249, upload-time = "2026-03-11T21:39:20.133Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0c/2d0c4897e43f1bb1b68dad840551cda224696eda9951524db50721d3bc18/chardet-7.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6f806f325825325e0682226269a2a4859993344cccca14f2463855d4f5a93272", size = 534544, upload-time = "2026-03-11T21:39:21.844Z" },
+    { url = "https://files.pythonhosted.org/packages/17/cb/a568eea24adc1a023da266854e9fc9e0eaffa72580d43c45b47f1b62dd2e/chardet-7.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bacc8f862998c59e9ee7fe4960538300d1cc3fe2c293b9cc99bbbc7bf3bedf51", size = 555894, upload-time = "2026-03-11T21:39:23.649Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/e7/958975ca18c7b5be9b94354c302a7f3d757c02e7c14e88e0c85af1e16c70/chardet-7.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c35d17822fc94467b7951adebd897cb01c0e37ac694be18d2cbd2b676d61df4f", size = 559286, upload-time = "2026-03-11T21:39:25.289Z" },
+    { url = "https://files.pythonhosted.org/packages/84/0b/1eddfd650e98bb80ec9f74c0bb98fa60cc36f63d9209214cd069b2a27340/chardet-7.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:b951107b254cdc766e52f4b8339dcfa97c7b45ca9f5509075308db2497e7f3af", size = 526406, upload-time = "2026-03-11T21:39:27.103Z" },
+    { url = "https://files.pythonhosted.org/packages/87/13/6aa6c9118ce153a806bb0472e27e8f8c24e6925db8a5b9fe99e03e45af15/chardet-7.1.0-py3-none-any.whl", hash = "sha256:7f677725333bf53f84b7f57458f44669a8a5eb2ac4092ac699cdfa9b1af08a5f", size = 411334, upload-time = "2026-03-11T21:39:36.198Z" },
 ]
 
 [[package]]
 name = "charset-normalizer"
-version = "3.4.4"
+version = "3.4.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", size = 129418, upload-time = "2025-10-14T04:42:32.879Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/35/02daf95b9cd686320bb622eb148792655c9412dbb9b67abb5694e5910a24/charset_normalizer-3.4.5.tar.gz", hash = "sha256:95adae7b6c42a6c5b5b559b1a99149f090a57128155daeea91732c8d970d8644", size = 134804, upload-time = "2026-03-06T06:03:19.46Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/85/1637cd4af66fa687396e757dec650f28025f2a2f5a5531a3208dc0ec43f2/charset_normalizer-3.4.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0a98e6759f854bd25a58a73fa88833fba3b7c491169f86ce1180c948ab3fd394", size = 208425, upload-time = "2025-10-14T04:40:53.353Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/6a/04130023fef2a0d9c62d0bae2649b69f7b7d8d24ea5536feef50551029df/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b5b290ccc2a263e8d185130284f8501e3e36c5e02750fc6b6bdeb2e9e96f1e25", size = 148162, upload-time = "2025-10-14T04:40:54.558Z" },
-    { url = "https://files.pythonhosted.org/packages/78/29/62328d79aa60da22c9e0b9a66539feae06ca0f5a4171ac4f7dc285b83688/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74bb723680f9f7a6234dcf67aea57e708ec1fbdf5699fb91dfd6f511b0a320ef", size = 144558, upload-time = "2025-10-14T04:40:55.677Z" },
-    { url = "https://files.pythonhosted.org/packages/86/bb/b32194a4bf15b88403537c2e120b817c61cd4ecffa9b6876e941c3ee38fe/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f1e34719c6ed0b92f418c7c780480b26b5d9c50349e9a9af7d76bf757530350d", size = 161497, upload-time = "2025-10-14T04:40:57.217Z" },
-    { url = "https://files.pythonhosted.org/packages/19/89/a54c82b253d5b9b111dc74aca196ba5ccfcca8242d0fb64146d4d3183ff1/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2437418e20515acec67d86e12bf70056a33abdacb5cb1655042f6538d6b085a8", size = 159240, upload-time = "2025-10-14T04:40:58.358Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/10/d20b513afe03acc89ec33948320a5544d31f21b05368436d580dec4e234d/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11d694519d7f29d6cd09f6ac70028dba10f92f6cdd059096db198c283794ac86", size = 153471, upload-time = "2025-10-14T04:40:59.468Z" },
-    { url = "https://files.pythonhosted.org/packages/61/fa/fbf177b55bdd727010f9c0a3c49eefa1d10f960e5f09d1d887bf93c2e698/charset_normalizer-3.4.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ac1c4a689edcc530fc9d9aa11f5774b9e2f33f9a0c6a57864e90908f5208d30a", size = 150864, upload-time = "2025-10-14T04:41:00.623Z" },
-    { url = "https://files.pythonhosted.org/packages/05/12/9fbc6a4d39c0198adeebbde20b619790e9236557ca59fc40e0e3cebe6f40/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:21d142cc6c0ec30d2efee5068ca36c128a30b0f2c53c1c07bd78cb6bc1d3be5f", size = 150647, upload-time = "2025-10-14T04:41:01.754Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/1f/6a9a593d52e3e8c5d2b167daf8c6b968808efb57ef4c210acb907c365bc4/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5dbe56a36425d26d6cfb40ce79c314a2e4dd6211d51d6d2191c00bed34f354cc", size = 145110, upload-time = "2025-10-14T04:41:03.231Z" },
-    { url = "https://files.pythonhosted.org/packages/30/42/9a52c609e72471b0fc54386dc63c3781a387bb4fe61c20231a4ebcd58bdd/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:5bfbb1b9acf3334612667b61bd3002196fe2a1eb4dd74d247e0f2a4d50ec9bbf", size = 162839, upload-time = "2025-10-14T04:41:04.715Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/5b/c0682bbf9f11597073052628ddd38344a3d673fda35a36773f7d19344b23/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:d055ec1e26e441f6187acf818b73564e6e6282709e9bcb5b63f5b23068356a15", size = 150667, upload-time = "2025-10-14T04:41:05.827Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/24/a41afeab6f990cf2daf6cb8c67419b63b48cf518e4f56022230840c9bfb2/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:af2d8c67d8e573d6de5bc30cdb27e9b95e49115cd9baad5ddbd1a6207aaa82a9", size = 160535, upload-time = "2025-10-14T04:41:06.938Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/e5/6a4ce77ed243c4a50a1fecca6aaaab419628c818a49434be428fe24c9957/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:780236ac706e66881f3b7f2f32dfe90507a09e67d1d454c762cf642e6e1586e0", size = 154816, upload-time = "2025-10-14T04:41:08.101Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/ef/89297262b8092b312d29cdb2517cb1237e51db8ecef2e9af5edbe7b683b1/charset_normalizer-3.4.4-cp312-cp312-win32.whl", hash = "sha256:5833d2c39d8896e4e19b689ffc198f08ea58116bee26dea51e362ecc7cd3ed26", size = 99694, upload-time = "2025-10-14T04:41:09.23Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/2d/1e5ed9dd3b3803994c155cd9aacb60c82c331bad84daf75bcb9c91b3295e/charset_normalizer-3.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:a79cfe37875f822425b89a82333404539ae63dbdddf97f84dcbc3d339aae9525", size = 107131, upload-time = "2025-10-14T04:41:10.467Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/d9/0ed4c7098a861482a7b6a95603edce4c0d9db2311af23da1fb2b75ec26fc/charset_normalizer-3.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:376bec83a63b8021bb5c8ea75e21c4ccb86e7e45ca4eb81146091b56599b80c3", size = 100390, upload-time = "2025-10-14T04:41:11.915Z" },
-    { url = "https://files.pythonhosted.org/packages/97/45/4b3a1239bbacd321068ea6e7ac28875b03ab8bc0aa0966452db17cd36714/charset_normalizer-3.4.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e1f185f86a6f3403aa2420e815904c67b2f9ebc443f045edd0de921108345794", size = 208091, upload-time = "2025-10-14T04:41:13.346Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/62/73a6d7450829655a35bb88a88fca7d736f9882a27eacdca2c6d505b57e2e/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b39f987ae8ccdf0d2642338faf2abb1862340facc796048b604ef14919e55ed", size = 147936, upload-time = "2025-10-14T04:41:14.461Z" },
-    { url = "https://files.pythonhosted.org/packages/89/c5/adb8c8b3d6625bef6d88b251bbb0d95f8205831b987631ab0c8bb5d937c2/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3162d5d8ce1bb98dd51af660f2121c55d0fa541b46dff7bb9b9f86ea1d87de72", size = 144180, upload-time = "2025-10-14T04:41:15.588Z" },
-    { url = "https://files.pythonhosted.org/packages/91/ed/9706e4070682d1cc219050b6048bfd293ccf67b3d4f5a4f39207453d4b99/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:81d5eb2a312700f4ecaa977a8235b634ce853200e828fbadf3a9c50bab278328", size = 161346, upload-time = "2025-10-14T04:41:16.738Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/0d/031f0d95e4972901a2f6f09ef055751805ff541511dc1252ba3ca1f80cf5/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5bd2293095d766545ec1a8f612559f6b40abc0eb18bb2f5d1171872d34036ede", size = 158874, upload-time = "2025-10-14T04:41:17.923Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/83/6ab5883f57c9c801ce5e5677242328aa45592be8a00644310a008d04f922/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a8a8b89589086a25749f471e6a900d3f662d1d3b6e2e59dcecf787b1cc3a1894", size = 153076, upload-time = "2025-10-14T04:41:19.106Z" },
-    { url = "https://files.pythonhosted.org/packages/75/1e/5ff781ddf5260e387d6419959ee89ef13878229732732ee73cdae01800f2/charset_normalizer-3.4.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc7637e2f80d8530ee4a78e878bce464f70087ce73cf7c1caf142416923b98f1", size = 150601, upload-time = "2025-10-14T04:41:20.245Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/57/71be810965493d3510a6ca79b90c19e48696fb1ff964da319334b12677f0/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f8bf04158c6b607d747e93949aa60618b61312fe647a6369f88ce2ff16043490", size = 150376, upload-time = "2025-10-14T04:41:21.398Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/d5/c3d057a78c181d007014feb7e9f2e65905a6c4ef182c0ddf0de2924edd65/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:554af85e960429cf30784dd47447d5125aaa3b99a6f0683589dbd27e2f45da44", size = 144825, upload-time = "2025-10-14T04:41:22.583Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/8c/d0406294828d4976f275ffbe66f00266c4b3136b7506941d87c00cab5272/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:74018750915ee7ad843a774364e13a3db91682f26142baddf775342c3f5b1133", size = 162583, upload-time = "2025-10-14T04:41:23.754Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/24/e2aa1f18c8f15c4c0e932d9287b8609dd30ad56dbe41d926bd846e22fb8d/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c0463276121fdee9c49b98908b3a89c39be45d86d1dbaa22957e38f6321d4ce3", size = 150366, upload-time = "2025-10-14T04:41:25.27Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/5b/1e6160c7739aad1e2df054300cc618b06bf784a7a164b0f238360721ab86/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:362d61fd13843997c1c446760ef36f240cf81d3ebf74ac62652aebaf7838561e", size = 160300, upload-time = "2025-10-14T04:41:26.725Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/10/f882167cd207fbdd743e55534d5d9620e095089d176d55cb22d5322f2afd/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9a26f18905b8dd5d685d6d07b0cdf98a79f3c7a918906af7cc143ea2e164c8bc", size = 154465, upload-time = "2025-10-14T04:41:28.322Z" },
-    { url = "https://files.pythonhosted.org/packages/89/66/c7a9e1b7429be72123441bfdbaf2bc13faab3f90b933f664db506dea5915/charset_normalizer-3.4.4-cp313-cp313-win32.whl", hash = "sha256:9b35f4c90079ff2e2edc5b26c0c77925e5d2d255c42c74fdb70fb49b172726ac", size = 99404, upload-time = "2025-10-14T04:41:29.95Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/26/b9924fa27db384bdcd97ab83b4f0a8058d96ad9626ead570674d5e737d90/charset_normalizer-3.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:b435cba5f4f750aa6c0a0d92c541fb79f69a387c91e61f1795227e4ed9cece14", size = 107092, upload-time = "2025-10-14T04:41:31.188Z" },
-    { url = "https://files.pythonhosted.org/packages/af/8f/3ed4bfa0c0c72a7ca17f0380cd9e4dd842b09f664e780c13cff1dcf2ef1b/charset_normalizer-3.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:542d2cee80be6f80247095cc36c418f7bddd14f4a6de45af91dfad36d817bba2", size = 100408, upload-time = "2025-10-14T04:41:32.624Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/b6/9ee9c1a608916ca5feae81a344dffbaa53b26b90be58cc2159e3332d44ec/charset_normalizer-3.4.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ed97c282ee4f994ef814042423a529df9497e3c666dca19be1d4cd1129dc7ade", size = 280976, upload-time = "2026-03-06T06:01:15.276Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d8/a54f7c0b96f1df3563e9190f04daf981e365a9b397eedfdfb5dbef7e5c6c/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0294916d6ccf2d069727d65973c3a1ca477d68708db25fd758dd28b0827cff54", size = 189356, upload-time = "2026-03-06T06:01:16.511Z" },
+    { url = "https://files.pythonhosted.org/packages/42/69/2bf7f76ce1446759a5787cb87d38f6a61eb47dbbdf035cfebf6347292a65/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dc57a0baa3eeedd99fafaef7511b5a6ef4581494e8168ee086031744e2679467", size = 206369, upload-time = "2026-03-06T06:01:17.853Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9c/949d1a46dab56b959d9a87272482195f1840b515a3380e39986989a893ae/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ed1a9a204f317ef879b32f9af507d47e49cd5e7f8e8d5d96358c98373314fc60", size = 203285, upload-time = "2026-03-06T06:01:19.473Z" },
+    { url = "https://files.pythonhosted.org/packages/67/5c/ae30362a88b4da237d71ea214a8c7eb915db3eec941adda511729ac25fa2/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7ad83b8f9379176c841f8865884f3514d905bcd2a9a3b210eaa446e7d2223e4d", size = 196274, upload-time = "2026-03-06T06:01:20.728Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/07/c9f2cb0e46cb6d64fdcc4f95953747b843bb2181bda678dc4e699b8f0f9a/charset_normalizer-3.4.5-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:a118e2e0b5ae6b0120d5efa5f866e58f2bb826067a646431da4d6a2bdae7950e", size = 184715, upload-time = "2026-03-06T06:01:22.194Z" },
+    { url = "https://files.pythonhosted.org/packages/36/64/6b0ca95c44fddf692cd06d642b28f63009d0ce325fad6e9b2b4d0ef86a52/charset_normalizer-3.4.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:754f96058e61a5e22e91483f823e07df16416ce76afa4ebf306f8e1d1296d43f", size = 193426, upload-time = "2026-03-06T06:01:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/50/bc/a730690d726403743795ca3f5bb2baf67838c5fea78236098f324b965e40/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0c300cefd9b0970381a46394902cd18eaf2aa00163f999590ace991989dcd0fc", size = 191780, upload-time = "2026-03-06T06:01:25.053Z" },
+    { url = "https://files.pythonhosted.org/packages/97/4f/6c0bc9af68222b22951552d73df4532b5be6447cee32d58e7e8c74ecbb7b/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:c108f8619e504140569ee7de3f97d234f0fbae338a7f9f360455071ef9855a95", size = 185805, upload-time = "2026-03-06T06:01:26.294Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/b9/a523fb9b0ee90814b503452b2600e4cbc118cd68714d57041564886e7325/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:d1028de43596a315e2720a9849ee79007ab742c06ad8b45a50db8cdb7ed4a82a", size = 208342, upload-time = "2026-03-06T06:01:27.55Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/61/c59e761dee4464050713e50e27b58266cc8e209e518c0b378c1580c959ba/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:19092dde50335accf365cce21998a1c6dd8eafd42c7b226eb54b2747cdce2fac", size = 193661, upload-time = "2026-03-06T06:01:29.051Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/43/729fa30aad69783f755c5ad8649da17ee095311ca42024742701e202dc59/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:4354e401eb6dab9aed3c7b4030514328a6c748d05e1c3e19175008ca7de84fb1", size = 204819, upload-time = "2026-03-06T06:01:30.298Z" },
+    { url = "https://files.pythonhosted.org/packages/87/33/d9b442ce5a91b96fc0840455a9e49a611bbadae6122778d0a6a79683dd31/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a68766a3c58fde7f9aaa22b3786276f62ab2f594efb02d0a1421b6282e852e98", size = 198080, upload-time = "2026-03-06T06:01:31.478Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5a/b8b5a23134978ee9885cee2d6995f4c27cc41f9baded0a9685eabc5338f0/charset_normalizer-3.4.5-cp312-cp312-win32.whl", hash = "sha256:1827734a5b308b65ac54e86a618de66f935a4f63a8a462ff1e19a6788d6c2262", size = 132630, upload-time = "2026-03-06T06:01:33.056Z" },
+    { url = "https://files.pythonhosted.org/packages/70/53/e44a4c07e8904500aec95865dc3f6464dc3586a039ef0df606eb3ac38e35/charset_normalizer-3.4.5-cp312-cp312-win_amd64.whl", hash = "sha256:728c6a963dfab66ef865f49286e45239384249672cd598576765acc2a640a636", size = 142856, upload-time = "2026-03-06T06:01:34.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/aa/c5628f7cad591b1cf45790b7a61483c3e36cf41349c98af7813c483fd6e8/charset_normalizer-3.4.5-cp312-cp312-win_arm64.whl", hash = "sha256:75dfd1afe0b1647449e852f4fb428195a7ed0588947218f7ba929f6538487f02", size = 132982, upload-time = "2026-03-06T06:01:35.641Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/48/9f34ec4bb24aa3fdba1890c1bddb97c8a4be1bd84ef5c42ac2352563ad05/charset_normalizer-3.4.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ac59c15e3f1465f722607800c68713f9fbc2f672b9eb649fe831da4019ae9b23", size = 280788, upload-time = "2026-03-06T06:01:37.126Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/09/6003e7ffeb90cc0560da893e3208396a44c210c5ee42efff539639def59b/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:165c7b21d19365464e8f70e5ce5e12524c58b48c78c1f5a57524603c1ab003f8", size = 188890, upload-time = "2026-03-06T06:01:38.73Z" },
+    { url = "https://files.pythonhosted.org/packages/42/1e/02706edf19e390680daa694d17e2b8eab4b5f7ac285e2a51168b4b22ee6b/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:28269983f25a4da0425743d0d257a2d6921ea7d9b83599d4039486ec5b9f911d", size = 206136, upload-time = "2026-03-06T06:01:40.016Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/87/942c3def1b37baf3cf786bad01249190f3ca3d5e63a84f831e704977de1f/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d27ce22ec453564770d29d03a9506d449efbb9fa13c00842262b2f6801c48cce", size = 202551, upload-time = "2026-03-06T06:01:41.522Z" },
+    { url = "https://files.pythonhosted.org/packages/94/0a/af49691938dfe175d71b8a929bd7e4ace2809c0c5134e28bc535660d5262/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0625665e4ebdddb553ab185de5db7054393af8879fb0c87bd5690d14379d6819", size = 195572, upload-time = "2026-03-06T06:01:43.208Z" },
+    { url = "https://files.pythonhosted.org/packages/20/ea/dfb1792a8050a8e694cfbde1570ff97ff74e48afd874152d38163d1df9ae/charset_normalizer-3.4.5-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:c23eb3263356d94858655b3e63f85ac5d50970c6e8febcdde7830209139cc37d", size = 184438, upload-time = "2026-03-06T06:01:44.755Z" },
+    { url = "https://files.pythonhosted.org/packages/72/12/c281e2067466e3ddd0595bfaea58a6946765ace5c72dfa3edc2f5f118026/charset_normalizer-3.4.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e6302ca4ae283deb0af68d2fbf467474b8b6aedcd3dab4db187e07f94c109763", size = 193035, upload-time = "2026-03-06T06:01:46.051Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/4f/3792c056e7708e10464bad0438a44708886fb8f92e3c3d29ec5e2d964d42/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e51ae7d81c825761d941962450f50d041db028b7278e7b08930b4541b3e45cb9", size = 191340, upload-time = "2026-03-06T06:01:47.547Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/86/80ddba897127b5c7a9bccc481b0cd36c8fefa485d113262f0fe4332f0bf4/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:597d10dec876923e5c59e48dbd366e852eacb2b806029491d307daea6b917d7c", size = 185464, upload-time = "2026-03-06T06:01:48.764Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/00/b5eff85ba198faacab83e0e4b6f0648155f072278e3b392a82478f8b988b/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5cffde4032a197bd3b42fd0b9509ec60fb70918d6970e4cc773f20fc9180ca67", size = 208014, upload-time = "2026-03-06T06:01:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/11/d36f70be01597fd30850dde8a1269ebc8efadd23ba5785808454f2389bde/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2da4eedcb6338e2321e831a0165759c0c620e37f8cd044a263ff67493be8ffb3", size = 193297, upload-time = "2026-03-06T06:01:51.933Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/1d/259eb0a53d4910536c7c2abb9cb25f4153548efb42800c6a9456764649c0/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:65a126fb4b070d05340a84fc709dd9e7c75d9b063b610ece8a60197a291d0adf", size = 204321, upload-time = "2026-03-06T06:01:53.887Z" },
+    { url = "https://files.pythonhosted.org/packages/84/31/faa6c5b9d3688715e1ed1bb9d124c384fe2fc1633a409e503ffe1c6398c1/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c7a80a9242963416bd81f99349d5f3fce1843c303bd404f204918b6d75a75fd6", size = 197509, upload-time = "2026-03-06T06:01:56.439Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a5/c7d9dd1503ffc08950b3260f5d39ec2366dd08254f0900ecbcf3a6197c7c/charset_normalizer-3.4.5-cp313-cp313-win32.whl", hash = "sha256:f1d725b754e967e648046f00c4facc42d414840f5ccc670c5670f59f83693e4f", size = 132284, upload-time = "2026-03-06T06:01:57.812Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/0f/57072b253af40c8aa6636e6de7d75985624c1eb392815b2f934199340a89/charset_normalizer-3.4.5-cp313-cp313-win_amd64.whl", hash = "sha256:e37bd100d2c5d3ba35db9c7c5ba5a9228cbcffe5c4778dc824b164e5257813d7", size = 142630, upload-time = "2026-03-06T06:01:59.062Z" },
+    { url = "https://files.pythonhosted.org/packages/31/41/1c4b7cc9f13bd9d369ce3bc993e13d374ce25fa38a2663644283ecf422c1/charset_normalizer-3.4.5-cp313-cp313-win_arm64.whl", hash = "sha256:93b3b2cc5cf1b8743660ce77a4f45f3f6d1172068207c1defc779a36eea6bb36", size = 133254, upload-time = "2026-03-06T06:02:00.281Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/60/3a621758945513adfd4db86827a5bafcc615f913dbd0b4c2ed64a65731be/charset_normalizer-3.4.5-py3-none-any.whl", hash = "sha256:9db5e3fcdcee89a78c04dffb3fe33c79f77bd741a624946db2591c81b2fc85b0", size = 55455, upload-time = "2026-03-06T06:03:17.827Z" },
 ]
 
 [[package]]
@@ -550,23 +565,25 @@ dependencies = [
     { name = "lameenc" },
     { name = "openunmix" },
     { name = "pyyaml" },
-    { name = "torch" },
-    { name = "torchaudio" },
+    { name = "torch", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "torchaudio", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "torchaudio", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
     { name = "tqdm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/87/38/55f835ebd9f443465087a6954ede19d4a41aebdf5e28567e89b99d6d2f57/demucs-4.0.1.tar.gz", hash = "sha256:e45a5a788bae79767c37bbf6e69aae03862ddcca05550fb79b926346a177d713", size = 1212924, upload-time = "2023-09-07T16:09:01.334Z" }
 
 [[package]]
 name = "deno"
-version = "2.7.4"
+version = "2.7.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9c/49/3abb94488985e282c85fceb0d316c765a3a027947e8628ec009c8e946928/deno-2.7.4.tar.gz", hash = "sha256:262e0a6bee1a4a218a52baf433b96783ae3751440be3d3af195a1bf46ac39fe8", size = 8164, upload-time = "2026-03-05T14:37:57.562Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/31/8bbaf3fb6a41929ae161be0b2a79b2747b5e5490811573ef60af7e3aeac3/deno-2.7.5.tar.gz", hash = "sha256:50635e0462697fa6e79d90bcacbe98e19f785e604c0e5061754de89b3668af83", size = 8166, upload-time = "2026-03-11T12:48:44.286Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/50/f9bd1ffa8190e95a6134cb2727be49313e3c23bf3c7e79a09146f881834e/deno-2.7.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:8e53b7118f9cd61af22da63468d21e94507a4be74dd4ce523cffcaea047509b6", size = 46360063, upload-time = "2026-03-05T14:37:40.598Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/ec/1d015a1c19203977ba79b2c8de710872da6e09659df8ded55470ac34732f/deno-2.7.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e46b936f433f6130012acd3960bd9519148bf4dd8b5c1b0e0e278ea558ec1859", size = 43288673, upload-time = "2026-03-05T14:37:43.658Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/53/fd9ad124ad9710c554d6cc7a49e9bd9d1b5077eb37258d34e8a69070395d/deno-2.7.4-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:4489e8db4d002724b40b32c5be988e6628de882abcd4aae612fc2267349f9e40", size = 47042429, upload-time = "2026-03-05T14:37:48.223Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/7c/33be6934ee31e4d2ff5b23d8ebf34c8b5170d8ec134bb033bee7b75c9573/deno-2.7.4-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:2fa937d81e96b89d82ab62ed1b448eb842e35ee8baa0f4aeca0857e431235cf0", size = 49014041, upload-time = "2026-03-05T14:37:51.388Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/65/3a5ff9e16ae52319627c331363e52f4266e5f69a013169846bb26ebb42d5/deno-2.7.4-py3-none-win_amd64.whl", hash = "sha256:d7fc9a55d8ef919b17752386791bda20ac6bd58f874223541b8f6a877f5f83e9", size = 48391513, upload-time = "2026-03-05T14:37:54.646Z" },
+    { url = "https://files.pythonhosted.org/packages/68/15/47c4b8da4e1b312ab14a2517e3f484c4d67a879cb5099cb6c33b8ce00c8c/deno-2.7.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:29cb89cdaea5f36133841fb4da058b1c6cb70d117ebfc7a24c717747b58e8503", size = 46641593, upload-time = "2026-03-11T12:48:16.589Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3a/c3f8842b7499ff3faeb7508711a82b736d3a4c6e0ffb359191386bcf539d/deno-2.7.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6456980341e97e4eb88e0c560fa57cd1b5f732e0eaadccc6c47d5ada73a71ff3", size = 43537874, upload-time = "2026-03-11T12:48:21.958Z" },
+    { url = "https://files.pythonhosted.org/packages/71/a2/53a013ba3509648582748678d5c6980210a45e0913934f91bfe1ec237e07/deno-2.7.5-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:fdc1e647a06ef792643237c030f45295692b0abc05d5bc9894fb11fd70876953", size = 47265090, upload-time = "2026-03-11T12:48:26.819Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/85/88c76daa72575f7229bb94191f15f4771f0614227bf8467bfe06e051f4ab/deno-2.7.5-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:c15e6b8ccf5f0808cd5ba243ea4eea7d8d78f6fdff228f5c6c85b96ba286bd3c", size = 49262188, upload-time = "2026-03-11T12:48:32.125Z" },
+    { url = "https://files.pythonhosted.org/packages/42/5e/501a92ef93d6d46ed8a1a8c03cff8bcbccbc06c1f59b163113ff09cd23cf/deno-2.7.5-py3-none-win_amd64.whl", hash = "sha256:3e3d06006ee39901dd23068c4a501a4a524fb71c323e22503b1b2ddf236da463", size = 48481169, upload-time = "2026-03-11T12:48:38.684Z" },
 ]
 
 [[package]]
@@ -592,7 +609,8 @@ dependencies = [
     { name = "omegaconf" },
     { name = "retrying" },
     { name = "submitit" },
-    { name = "torch" },
+    { name = "torch", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
     { name = "treetable" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d5/9d/9a13947db237375486c0690f4741dd2b7e1eee20e0ffcb55dbd1b21cc600/dora_search-0.1.12.tar.gz", hash = "sha256:2956fd2c4c7e4b9a4830e83f0d4cf961be45cfba1a2f0570281e91d15ac516fb", size = 87111, upload-time = "2023-05-23T14:36:24.743Z" }
@@ -636,11 +654,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.24.3"
+version = "3.25.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/92/a8e2479937ff39185d20dd6a851c1a63e55849e447a55e798cc2e1f49c65/filelock-3.24.3.tar.gz", hash = "sha256:011a5644dc937c22699943ebbfc46e969cdde3e171470a6e40b9533e5a72affa", size = 37935, upload-time = "2026-02-19T00:48:20.543Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480, upload-time = "2026-03-11T20:45:38.487Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/0f/5d0c71a1aefeb08efff26272149e07ab922b64f46c63363756224bd6872e/filelock-3.24.3-py3-none-any.whl", hash = "sha256:426e9a4660391f7f8a810d71b0555bce9008b0a1cc342ab1f6947d37639e002d", size = 24331, upload-time = "2026-02-19T00:48:18.465Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759, upload-time = "2026-03-11T20:45:37.437Z" },
 ]
 
 [[package]]
@@ -653,27 +671,27 @@ wheels = [
 
 [[package]]
 name = "fonttools"
-version = "4.61.1"
+version = "4.62.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ec/ca/cf17b88a8df95691275a3d77dc0a5ad9907f328ae53acbe6795da1b2f5ed/fonttools-4.61.1.tar.gz", hash = "sha256:6675329885c44657f826ef01d9e4fb33b9158e9d93c537d84ad8399539bc6f69", size = 3565756, upload-time = "2025-12-12T17:31:24.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/96/686339e0fda8142b7ebed39af53f4a5694602a729662f42a6209e3be91d0/fonttools-4.62.0.tar.gz", hash = "sha256:0dc477c12b8076b4eb9af2e440421b0433ffa9e1dcb39e0640a6c94665ed1098", size = 3579521, upload-time = "2026-03-09T16:50:06.217Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/16/7decaa24a1bd3a70c607b2e29f0adc6159f36a7e40eaba59846414765fd4/fonttools-4.61.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f3cb4a569029b9f291f88aafc927dd53683757e640081ca8c412781ea144565e", size = 2851593, upload-time = "2025-12-12T17:30:04.225Z" },
-    { url = "https://files.pythonhosted.org/packages/94/98/3c4cb97c64713a8cf499b3245c3bf9a2b8fd16a3e375feff2aed78f96259/fonttools-4.61.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:41a7170d042e8c0024703ed13b71893519a1a6d6e18e933e3ec7507a2c26a4b2", size = 2400231, upload-time = "2025-12-12T17:30:06.47Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/37/82dbef0f6342eb01f54bca073ac1498433d6ce71e50c3c3282b655733b31/fonttools-4.61.1-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:10d88e55330e092940584774ee5e8a6971b01fc2f4d3466a1d6c158230880796", size = 4954103, upload-time = "2025-12-12T17:30:08.432Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/44/f3aeac0fa98e7ad527f479e161aca6c3a1e47bb6996b053d45226fe37bf2/fonttools-4.61.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:15acc09befd16a0fb8a8f62bc147e1a82817542d72184acca9ce6e0aeda9fa6d", size = 5004295, upload-time = "2025-12-12T17:30:10.56Z" },
-    { url = "https://files.pythonhosted.org/packages/14/e8/7424ced75473983b964d09f6747fa09f054a6d656f60e9ac9324cf40c743/fonttools-4.61.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e6bcdf33aec38d16508ce61fd81838f24c83c90a1d1b8c68982857038673d6b8", size = 4944109, upload-time = "2025-12-12T17:30:12.874Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/8b/6391b257fa3d0b553d73e778f953a2f0154292a7a7a085e2374b111e5410/fonttools-4.61.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5fade934607a523614726119164ff621e8c30e8fa1ffffbbd358662056ba69f0", size = 5093598, upload-time = "2025-12-12T17:30:15.79Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/71/fd2ea96cdc512d92da5678a1c98c267ddd4d8c5130b76d0f7a80f9a9fde8/fonttools-4.61.1-cp312-cp312-win32.whl", hash = "sha256:75da8f28eff26defba42c52986de97b22106cb8f26515b7c22443ebc9c2d3261", size = 2269060, upload-time = "2025-12-12T17:30:18.058Z" },
-    { url = "https://files.pythonhosted.org/packages/80/3b/a3e81b71aed5a688e89dfe0e2694b26b78c7d7f39a5ffd8a7d75f54a12a8/fonttools-4.61.1-cp312-cp312-win_amd64.whl", hash = "sha256:497c31ce314219888c0e2fce5ad9178ca83fe5230b01a5006726cdf3ac9f24d9", size = 2319078, upload-time = "2025-12-12T17:30:22.862Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/cf/00ba28b0990982530addb8dc3e9e6f2fa9cb5c20df2abdda7baa755e8fe1/fonttools-4.61.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8c56c488ab471628ff3bfa80964372fc13504ece601e0d97a78ee74126b2045c", size = 2846454, upload-time = "2025-12-12T17:30:24.938Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/ca/468c9a8446a2103ae645d14fee3f610567b7042aba85031c1c65e3ef7471/fonttools-4.61.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:dc492779501fa723b04d0ab1f5be046797fee17d27700476edc7ee9ae535a61e", size = 2398191, upload-time = "2025-12-12T17:30:27.343Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/4b/d67eedaed19def5967fade3297fed8161b25ba94699efc124b14fb68cdbc/fonttools-4.61.1-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:64102ca87e84261419c3747a0d20f396eb024bdbeb04c2bfb37e2891f5fadcb5", size = 4928410, upload-time = "2025-12-12T17:30:29.771Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/8d/6fb3494dfe61a46258cd93d979cf4725ded4eb46c2a4ca35e4490d84daea/fonttools-4.61.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c1b526c8d3f615a7b1867f38a9410849c8f4aef078535742198e942fba0e9bd", size = 4984460, upload-time = "2025-12-12T17:30:32.073Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/f1/a47f1d30b3dc00d75e7af762652d4cbc3dff5c2697a0dbd5203c81afd9c3/fonttools-4.61.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:41ed4b5ec103bd306bb68f81dc166e77409e5209443e5773cb4ed837bcc9b0d3", size = 4925800, upload-time = "2025-12-12T17:30:34.339Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/01/e6ae64a0981076e8a66906fab01539799546181e32a37a0257b77e4aa88b/fonttools-4.61.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b501c862d4901792adaec7c25b1ecc749e2662543f68bb194c42ba18d6eec98d", size = 5067859, upload-time = "2025-12-12T17:30:36.593Z" },
-    { url = "https://files.pythonhosted.org/packages/73/aa/28e40b8d6809a9b5075350a86779163f074d2b617c15d22343fce81918db/fonttools-4.61.1-cp313-cp313-win32.whl", hash = "sha256:4d7092bb38c53bbc78e9255a59158b150bcdc115a1e3b3ce0b5f267dc35dd63c", size = 2267821, upload-time = "2025-12-12T17:30:38.478Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/59/453c06d1d83dc0951b69ef692d6b9f1846680342927df54e9a1ca91c6f90/fonttools-4.61.1-cp313-cp313-win_amd64.whl", hash = "sha256:21e7c8d76f62ab13c9472ccf74515ca5b9a761d1bde3265152a6dc58700d895b", size = 2318169, upload-time = "2025-12-12T17:30:40.951Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/4e/ce75a57ff3aebf6fc1f4e9d508b8e5810618a33d900ad6c19eb30b290b97/fonttools-4.61.1-py3-none-any.whl", hash = "sha256:17d2bf5d541add43822bcf0c43d7d847b160c9bb01d15d5007d84e2217aaa371", size = 1148996, upload-time = "2025-12-12T17:31:21.03Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/9d/7ad1ffc080619f67d0b1e0fa6a0578f0be077404f13fd8e448d1616a94a3/fonttools-4.62.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:22bde4dc12a9e09b5ced77f3b5053d96cf10c4976c6ac0dee293418ef289d221", size = 2870004, upload-time = "2026-03-09T16:48:50.837Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/8b/ba59069a490f61b737e064c3129453dbd28ee38e81d56af0d04d7e6b4de4/fonttools-4.62.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7199c73b326bad892f1cb53ffdd002128bfd58a89b8f662204fbf1daf8d62e85", size = 2414662, upload-time = "2026-03-09T16:48:53.295Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/8c/c52a4310de58deeac7e9ea800892aec09b00bb3eb0c53265b31ec02be115/fonttools-4.62.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d732938633681d6e2324e601b79e93f7f72395ec8681f9cdae5a8c08bc167e72", size = 5032975, upload-time = "2026-03-09T16:48:55.718Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a1/d16318232964d786907b9b3613b8409f74cf0be2da400854509d3a864e43/fonttools-4.62.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:31a804c16d76038cc4e3826e07678efb0a02dc4f15396ea8e07088adbfb2578e", size = 4988544, upload-time = "2026-03-09T16:48:57.715Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/8d/7e745ca3e65852adc5e52a83dc213fe1b07d61cb5b394970fcd4b1199d1e/fonttools-4.62.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:090e74ac86e68c20150e665ef8e7e0c20cb9f8b395302c9419fa2e4d332c3b51", size = 4971296, upload-time = "2026-03-09T16:48:59.678Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/d4/b717a4874175146029ca1517e85474b1af80c9d9a306fc3161e71485eea5/fonttools-4.62.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8f086120e8be9e99ca1288aa5ce519833f93fe0ec6ebad2380c1dee18781f0b5", size = 5122503, upload-time = "2026-03-09T16:49:02.464Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/4b/92cfcba4bf8373f51c49c5ae4b512ead6fbda7d61a0e8c35a369d0db40a0/fonttools-4.62.0-cp312-cp312-win32.whl", hash = "sha256:37a73e5e38fd05c637daede6ffed5f3496096be7df6e4a3198d32af038f87527", size = 2281060, upload-time = "2026-03-09T16:49:04.385Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/06/cc96468781a4dc8ae2f14f16f32b32f69bde18cb9384aad27ccc7adf76f7/fonttools-4.62.0-cp312-cp312-win_amd64.whl", hash = "sha256:658ab837c878c4d2a652fcbb319547ea41693890e6434cf619e66f79387af3b8", size = 2331193, upload-time = "2026-03-09T16:49:06.598Z" },
+    { url = "https://files.pythonhosted.org/packages/82/c7/985c1670aa6d82ef270f04cde11394c168f2002700353bd2bde405e59b8f/fonttools-4.62.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:274c8b8a87e439faf565d3bcd3f9f9e31bca7740755776a4a90a4bfeaa722efa", size = 2864929, upload-time = "2026-03-09T16:49:09.331Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/dc/c409c8ceec0d3119e9ab0b7b1a2e3c76d1f4d66e4a9db5c59e6b7652e7df/fonttools-4.62.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:93e27131a5a0ae82aaadcffe309b1bae195f6711689722af026862bede05c07c", size = 2412586, upload-time = "2026-03-09T16:49:11.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/ac/8e300dbf7b4d135287c261ffd92ede02d9f48f0d2db14665fbc8b059588a/fonttools-4.62.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:83c6524c5b93bad9c2939d88e619fedc62e913c19e673f25d5ab74e7a5d074e5", size = 5013708, upload-time = "2026-03-09T16:49:14.063Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/bc/60d93477b653eeb1ddf5f9ec34be689b79234d82dbdded269ac0252715b8/fonttools-4.62.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:106aec9226f9498fc5345125ff7200842c01eda273ae038f5049b0916907acee", size = 4964355, upload-time = "2026-03-09T16:49:16.515Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/eb/6dc62bcc3c3598c28a3ecb77e69018869c3e109bd83031d4973c059d318b/fonttools-4.62.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:15d86b96c79013320f13bc1b15f94789edb376c0a2d22fb6088f33637e8dfcbc", size = 4953472, upload-time = "2026-03-09T16:49:18.494Z" },
+    { url = "https://files.pythonhosted.org/packages/82/b3/3af7592d9b254b7b7fec018135f8776bfa0d1ad335476c2791b1334dc5e4/fonttools-4.62.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f16c07e5250d5d71d0f990a59460bc5620c3cc456121f2cfb5b60475699905f", size = 5094701, upload-time = "2026-03-09T16:49:21.67Z" },
+    { url = "https://files.pythonhosted.org/packages/31/3d/976645583ab567d3ee75ff87b33aa1330fa2baeeeae5fc46210b4274dd45/fonttools-4.62.0-cp313-cp313-win32.whl", hash = "sha256:d31558890f3fa00d4f937d12708f90c7c142c803c23eaeb395a71f987a77ebe3", size = 2279710, upload-time = "2026-03-09T16:49:23.812Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/7a/e25245a30457595740041dba9d0ea8ec1b2517f2f1a6a741f15eba1a4edc/fonttools-4.62.0-cp313-cp313-win_amd64.whl", hash = "sha256:6826a5aa53fb6def8a66bf423939745f415546c4e92478a7c531b8b6282b6c3b", size = 2330291, upload-time = "2026-03-09T16:49:26.237Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/57/c2487c281dde03abb2dec244fd67059b8d118bd30a653cbf69e94084cb23/fonttools-4.62.0-py3-none-any.whl", hash = "sha256:75064f19a10c50c74b336aa5ebe7b1f89fd0fb5255807bfd4b0c6317098f4af3", size = 1152427, upload-time = "2026-03-09T16:50:04.074Z" },
 ]
 
 [[package]]
@@ -758,14 +776,14 @@ wheels = [
 
 [[package]]
 name = "googleapis-common-protos"
-version = "1.72.0"
+version = "1.73.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/7b/adfd75544c415c487b33061fe7ae526165241c1ea133f9a9125a56b39fd8/googleapis_common_protos-1.72.0.tar.gz", hash = "sha256:e55a601c1b32b52d7a3e65f43563e2aa61bcd737998ee672ac9b951cd49319f5", size = 147433, upload-time = "2025-11-06T18:29:24.087Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/96/a0205167fa0154f4a542fd6925bdc63d039d88dab3588b875078107e6f06/googleapis_common_protos-1.73.0.tar.gz", hash = "sha256:778d07cd4fbeff84c6f7c72102f0daf98fa2bfd3fa8bea426edc545588da0b5a", size = 147323, upload-time = "2026-03-06T21:53:09.727Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/ab/09169d5a4612a5f92490806649ac8d41e3ec9129c636754575b3553f4ea4/googleapis_common_protos-1.72.0-py3-none-any.whl", hash = "sha256:4299c5a82d5ae1a9702ada957347726b167f9f8d1fc352477702a1e851ff4038", size = 297515, upload-time = "2025-11-06T18:29:13.14Z" },
+    { url = "https://files.pythonhosted.org/packages/69/28/23eea8acd65972bbfe295ce3666b28ac510dfcb115fac089d3edb0feb00a/googleapis_common_protos-1.73.0-py3-none-any.whl", hash = "sha256:dfdaaa2e860f242046be561e6d6cb5c5f1541ae02cfbcb034371aadb2942b4e8", size = 297578, upload-time = "2026-03-06T21:52:33.933Z" },
 ]
 
 [[package]]
@@ -794,55 +812,57 @@ wheels = [
 
 [[package]]
 name = "grpcio"
-version = "1.78.1"
+version = "1.78.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/de/de568532d9907552700f80dcec38219d8d298ad9e71f5e0a095abaf2761e/grpcio-1.78.1.tar.gz", hash = "sha256:27c625532d33ace45d57e775edf1982e183ff8641c72e4e91ef7ba667a149d72", size = 12835760, upload-time = "2026-02-20T01:16:10.869Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/8a/3d098f35c143a89520e568e6539cc098fcd294495910e359889ce8741c84/grpcio-1.78.0.tar.gz", hash = "sha256:7382b95189546f375c174f53a5fa873cef91c4b8005faa05cc5b3beea9c4f1c5", size = 12852416, upload-time = "2026-02-06T09:57:18.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/ed/d2eb9d27fded1a76b2a80eb9aa8b12101da7e41ce2bac0ad3651e88a14ae/grpcio-1.78.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:41e4605c923e0e9a84a2718e4948a53a530172bfaf1a6d1ded16ef9c5849fca2", size = 5913389, upload-time = "2026-02-20T01:13:49.005Z" },
-    { url = "https://files.pythonhosted.org/packages/69/1b/40034e9ab010eeb3fa41ec61d8398c6dbf7062f3872c866b8f72700e2522/grpcio-1.78.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:39da1680d260c0c619c3b5fa2dc47480ca24d5704c7a548098bca7de7f5dd17f", size = 11811839, upload-time = "2026-02-20T01:13:51.839Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/69/fe16ef2979ea62b8aceb3a3f1e7a8bbb8b717ae2a44b5899d5d426073273/grpcio-1.78.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b5d5881d72a09b8336a8f874784a8eeffacde44a7bc1a148bce5a0243a265ef0", size = 6475805, upload-time = "2026-02-20T01:13:55.423Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/1e/069e0a9062167db18446917d7c00ae2e91029f96078a072bedc30aaaa8c3/grpcio-1.78.1-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:888ceb7821acd925b1c90f0cdceaed1386e69cfe25e496e0771f6c35a156132f", size = 7169955, upload-time = "2026-02-20T01:13:59.553Z" },
-    { url = "https://files.pythonhosted.org/packages/38/fc/44a57e2bb4a755e309ee4e9ed2b85c9af93450b6d3118de7e69410ee05fa/grpcio-1.78.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8942bdfc143b467c264b048862090c4ba9a0223c52ae28c9ae97754361372e42", size = 6690767, upload-time = "2026-02-20T01:14:02.31Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/87/21e16345d4c75046d453916166bc72a3309a382c8e97381ec4b8c1a54729/grpcio-1.78.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:716a544969660ed609164aff27b2effd3ff84e54ac81aa4ce77b1607ca917d22", size = 7266846, upload-time = "2026-02-20T01:14:12.974Z" },
-    { url = "https://files.pythonhosted.org/packages/11/df/d6261983f9ca9ef4d69893765007a9a3211b91d9faf85a2591063df381c7/grpcio-1.78.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4d50329b081c223d444751076bb5b389d4f06c2b32d51b31a1e98172e6cecfb9", size = 8253522, upload-time = "2026-02-20T01:14:17.407Z" },
-    { url = "https://files.pythonhosted.org/packages/de/7c/4f96a0ff113c5d853a27084d7590cd53fdb05169b596ea9f5f27f17e021e/grpcio-1.78.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7e836778c13ff70edada16567e8da0c431e8818eaae85b80d11c1ba5782eccbb", size = 7698070, upload-time = "2026-02-20T01:14:20.032Z" },
-    { url = "https://files.pythonhosted.org/packages/17/3c/7b55c0b5af88fbeb3d0c13e25492d3ace41ac9dbd0f5f8f6c0fb613b6706/grpcio-1.78.1-cp312-cp312-win32.whl", hash = "sha256:07eb016ea7444a22bef465cce045512756956433f54450aeaa0b443b8563b9ca", size = 4066474, upload-time = "2026-02-20T01:14:22.602Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/17/388c12d298901b0acf10b612b650692bfed60e541672b1d8965acbf2d722/grpcio-1.78.1-cp312-cp312-win_amd64.whl", hash = "sha256:02b82dcd2fa580f5e82b4cf62ecde1b3c7cc9ba27b946421200706a6e5acaf85", size = 4797537, upload-time = "2026-02-20T01:14:25.444Z" },
-    { url = "https://files.pythonhosted.org/packages/df/72/754754639cfd16ad04619e1435a518124b2d858e5752225376f9285d4c51/grpcio-1.78.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:2b7ad2981550ce999e25ce3f10c8863f718a352a2fd655068d29ea3fd37b4907", size = 5919437, upload-time = "2026-02-20T01:14:29.403Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/84/6267d1266f8bc335d3a8b7ccf981be7de41e3ed8bd3a49e57e588212b437/grpcio-1.78.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:409bfe22220889b9906739910a0ee4c197a967c21b8dd14b4b06dd477f8819ce", size = 11803701, upload-time = "2026-02-20T01:14:32.624Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/56/c9098e8b920a54261cd605bbb040de0cde1ca4406102db0aa2c0b11d1fb4/grpcio-1.78.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:34b6cb16f4b67eeb5206250dc5b4d5e8e3db939535e58efc330e4c61341554bd", size = 6479416, upload-time = "2026-02-20T01:14:35.926Z" },
-    { url = "https://files.pythonhosted.org/packages/86/cf/5d52024371ee62658b7ed72480200524087528844ec1b65265bbcd31c974/grpcio-1.78.1-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:39d21fd30d38a5afb93f0e2e71e2ec2bd894605fb75d41d5a40060c2f98f8d11", size = 7174087, upload-time = "2026-02-20T01:14:39.98Z" },
-    { url = "https://files.pythonhosted.org/packages/31/e6/5e59551afad4279e27335a6d60813b8aa3ae7b14fb62cea1d329a459c118/grpcio-1.78.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:09fbd4bcaadb6d8604ed1504b0bdf7ac18e48467e83a9d930a70a7fefa27e862", size = 6692881, upload-time = "2026-02-20T01:14:42.466Z" },
-    { url = "https://files.pythonhosted.org/packages/db/8f/940062de2d14013c02f51b079eb717964d67d46f5d44f22038975c9d9576/grpcio-1.78.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:db681513a1bdd879c0b24a5a6a70398da5eaaba0e077a306410dc6008426847a", size = 7269092, upload-time = "2026-02-20T01:14:45.826Z" },
-    { url = "https://files.pythonhosted.org/packages/09/87/9db657a4b5f3b15560ec591db950bc75a1a2f9e07832578d7e2b23d1a7bd/grpcio-1.78.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f81816faa426da461e9a597a178832a351d6f1078102590a4b32c77d251b71eb", size = 8252037, upload-time = "2026-02-20T01:14:48.57Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/37/b980e0265479ec65e26b6e300a39ceac33ecb3f762c2861d4bac990317cf/grpcio-1.78.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ffbb760df1cd49e0989f9826b2fd48930700db6846ac171eaff404f3cfbe5c28", size = 7695243, upload-time = "2026-02-20T01:14:51.376Z" },
-    { url = "https://files.pythonhosted.org/packages/98/46/5fc42c100ab702fa1ea41a75c890c563c3f96432b4a287d5a6369654f323/grpcio-1.78.1-cp313-cp313-win32.whl", hash = "sha256:1a56bf3ee99af5cf32d469de91bf5de79bdac2e18082b495fc1063ea33f4f2d0", size = 4065329, upload-time = "2026-02-20T01:14:53.952Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/da/806d60bb6611dfc16cf463d982bd92bd8b6bd5f87dfac66b0a44dfe20995/grpcio-1.78.1-cp313-cp313-win_amd64.whl", hash = "sha256:8991c2add0d8505178ff6c3ae54bd9386279e712be82fa3733c54067aae9eda1", size = 4797637, upload-time = "2026-02-20T01:14:57.276Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/f4/7384ed0178203d6074446b3c4f46c90a22ddf7ae0b3aee521627f54cfc2a/grpcio-1.78.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:f9ab915a267fc47c7e88c387a3a28325b58c898e23d4995f765728f4e3dedb97", size = 5913985, upload-time = "2026-02-06T09:55:26.832Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ed/be1caa25f06594463f685b3790b320f18aea49b33166f4141bfdc2bfb236/grpcio-1.78.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3f8904a8165ab21e07e58bf3e30a73f4dffc7a1e0dbc32d51c61b5360d26f43e", size = 11811853, upload-time = "2026-02-06T09:55:29.224Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a7/f06d151afc4e64b7e3cc3e872d331d011c279aaab02831e40a81c691fb65/grpcio-1.78.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:859b13906ce098c0b493af92142ad051bf64c7870fa58a123911c88606714996", size = 6475766, upload-time = "2026-02-06T09:55:31.825Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a8/4482922da832ec0082d0f2cc3a10976d84a7424707f25780b82814aafc0a/grpcio-1.78.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b2342d87af32790f934a79c3112641e7b27d63c261b8b4395350dad43eff1dc7", size = 7170027, upload-time = "2026-02-06T09:55:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bf/f4a3b9693e35d25b24b0b39fa46d7d8a3c439e0a3036c3451764678fec20/grpcio-1.78.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:12a771591ae40bc65ba67048fa52ef4f0e6db8279e595fd349f9dfddeef571f9", size = 6690766, upload-time = "2026-02-06T09:55:36.902Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/b9/521875265cc99fe5ad4c5a17010018085cae2810a928bf15ebe7d8bcd9cc/grpcio-1.78.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:185dea0d5260cbb2d224c507bf2a5444d5abbb1fa3594c1ed7e4c709d5eb8383", size = 7266161, upload-time = "2026-02-06T09:55:39.824Z" },
+    { url = "https://files.pythonhosted.org/packages/05/86/296a82844fd40a4ad4a95f100b55044b4f817dece732bf686aea1a284147/grpcio-1.78.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:51b13f9aed9d59ee389ad666b8c2214cc87b5de258fa712f9ab05f922e3896c6", size = 8253303, upload-time = "2026-02-06T09:55:42.353Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/e4/ea3c0caf5468537f27ad5aab92b681ed7cc0ef5f8c9196d3fd42c8c2286b/grpcio-1.78.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd5f135b1bd58ab088930b3c613455796dfa0393626a6972663ccdda5b4ac6ce", size = 7698222, upload-time = "2026-02-06T09:55:44.629Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/47/7f05f81e4bb6b831e93271fb12fd52ba7b319b5402cbc101d588f435df00/grpcio-1.78.0-cp312-cp312-win32.whl", hash = "sha256:94309f498bcc07e5a7d16089ab984d42ad96af1d94b5a4eb966a266d9fcabf68", size = 4066123, upload-time = "2026-02-06T09:55:47.644Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/e7/d6914822c88aa2974dbbd10903d801a28a19ce9cd8bad7e694cbbcf61528/grpcio-1.78.0-cp312-cp312-win_amd64.whl", hash = "sha256:9566fe4ababbb2610c39190791e5b829869351d14369603702e890ef3ad2d06e", size = 4797657, upload-time = "2026-02-06T09:55:49.86Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a9/8f75894993895f361ed8636cd9237f4ab39ef87fd30db17467235ed1c045/grpcio-1.78.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:ce3a90455492bf8bfa38e56fbbe1dbd4f872a3d8eeaf7337dc3b1c8aa28c271b", size = 5920143, upload-time = "2026-02-06T09:55:52.035Z" },
+    { url = "https://files.pythonhosted.org/packages/55/06/0b78408e938ac424100100fd081189451b472236e8a3a1f6500390dc4954/grpcio-1.78.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:2bf5e2e163b356978b23652c4818ce4759d40f4712ee9ec5a83c4be6f8c23a3a", size = 11803926, upload-time = "2026-02-06T09:55:55.494Z" },
+    { url = "https://files.pythonhosted.org/packages/88/93/b59fe7832ff6ae3c78b813ea43dac60e295fa03606d14d89d2e0ec29f4f3/grpcio-1.78.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8f2ac84905d12918e4e55a16da17939eb63e433dc11b677267c35568aa63fc84", size = 6478628, upload-time = "2026-02-06T09:55:58.533Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/df/e67e3734527f9926b7d9c0dde6cd998d1d26850c3ed8eeec81297967ac67/grpcio-1.78.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b58f37edab4a3881bc6c9bca52670610e0c9ca14e2ea3cf9debf185b870457fb", size = 7173574, upload-time = "2026-02-06T09:56:01.786Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/cc03fffb07bfba982a9ec097b164e8835546980aec25ecfa5f9c1a47e022/grpcio-1.78.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:735e38e176a88ce41840c21bb49098ab66177c64c82426e24e0082500cc68af5", size = 6692639, upload-time = "2026-02-06T09:56:04.529Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/9a/289c32e301b85bdb67d7ec68b752155e674ee3ba2173a1858f118e399ef3/grpcio-1.78.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2045397e63a7a0ee7957c25f7dbb36ddc110e0cfb418403d110c0a7a68a844e9", size = 7268838, upload-time = "2026-02-06T09:56:08.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/79/1be93f32add280461fa4773880196572563e9c8510861ac2da0ea0f892b6/grpcio-1.78.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:a9f136fbafe7ccf4ac7e8e0c28b31066e810be52d6e344ef954a3a70234e1702", size = 8251878, upload-time = "2026-02-06T09:56:10.914Z" },
+    { url = "https://files.pythonhosted.org/packages/65/65/793f8e95296ab92e4164593674ae6291b204bb5f67f9d4a711489cd30ffa/grpcio-1.78.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:748b6138585379c737adc08aeffd21222abbda1a86a0dca2a39682feb9196c20", size = 7695412, upload-time = "2026-02-06T09:56:13.593Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9f/1e233fe697ecc82845942c2822ed06bb522e70d6771c28d5528e4c50f6a4/grpcio-1.78.0-cp313-cp313-win32.whl", hash = "sha256:271c73e6e5676afe4fc52907686670c7cea22ab2310b76a59b678403ed40d670", size = 4064899, upload-time = "2026-02-06T09:56:15.601Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/27/d86b89e36de8a951501fb06a0f38df19853210f341d0b28f83f4aa0ffa08/grpcio-1.78.0-cp313-cp313-win_amd64.whl", hash = "sha256:f2d4e43ee362adfc05994ed479334d5a451ab7bc3f3fee1b796b8ca66895acb4", size = 4797393, upload-time = "2026-02-06T09:56:17.882Z" },
 ]
 
 [[package]]
 name = "hf-xet"
-version = "1.3.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/3a/9aa61729228fb03e946409c51963f0cd2fd7c109f4ab93edc5f04a10be86/hf_xet-1.3.0.tar.gz", hash = "sha256:9c154ad63e17aca970987b2cf17dbd8a0c09bb18aeb246f637647a8058e4522b", size = 641390, upload-time = "2026-02-24T00:16:19.935Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/01/928fd82663fb0ab455551a178303a2960e65029da66b21974594f3a20a94/hf_xet-1.4.0.tar.gz", hash = "sha256:48e6ba7422b0885c9bbd8ac8fdf5c4e1306c3499b82d489944609cc4eae8ecbd", size = 660350, upload-time = "2026-03-11T18:50:03.354Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/18/16954a87cfdfdc04792f1ffc9a29c0a48253ab10ec0f4856f39c7f7bf7cd/hf_xet-1.3.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:95bdeab4747cb45f855601e39b9e86ae92b4a114978ada6e0401961fcc5d2958", size = 3759481, upload-time = "2026-02-24T00:16:03.387Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/6f/a55752047e9b0e69517775531c14680331f00c9cd4dc07f5e9b7f7f68a12/hf_xet-1.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:f99992583f27b139392601fe99e88df155dc4de7feba98ed27ce2d3e6b4a65bb", size = 3517927, upload-time = "2026-02-24T00:16:02.108Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/71/a909dbf9c8b166aa3f15db2bcf5d8afbe9d53170922edde2b919cf0bc455/hf_xet-1.3.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:687a71fc6d2eaa79d864da3aa13e5d887e124d357f5f306bfff6c385eea9d990", size = 4174328, upload-time = "2026-02-24T00:15:55.056Z" },
-    { url = "https://files.pythonhosted.org/packages/21/cc/dec0d971bb5872345b8d64363a0b78ed6a147eea5b4281575ce5a8150f42/hf_xet-1.3.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:75d19813ed0e24525409bc22566282ae9bc93e5d764b185565e863dc28280a45", size = 3953184, upload-time = "2026-02-24T00:15:53.43Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/d8/d4259146e7c7089dd3f22cd62676d665bcfbc27428a070abee8985e0ab33/hf_xet-1.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:078af43569c2e05233137a93a33d2293f95c272745eaf030a9bb5f27bb0c9e9c", size = 4152800, upload-time = "2026-02-24T00:16:10.391Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/0d/39d9d32e4cde689da618739197e264bba5a55d870377d5d32cdd5c03fad8/hf_xet-1.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:be8731e1620cc8549025c39ed3917c8fd125efaeae54ae679214a3d573e6c109", size = 4390499, upload-time = "2026-02-24T00:16:11.671Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/27/5b9c323bf5513e8971702eeac43ba5cb554921e0f292ad52f20ed6028131/hf_xet-1.3.0-cp313-cp313t-win_amd64.whl", hash = "sha256:1552616c0e0fa728a4ffdffa106e91faa0fd4edb44868e79b464fad00b2758ee", size = 3634124, upload-time = "2026-02-24T00:16:20.964Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/00/22d3d896466ded4c46ef6465b85fa434fa97d79f8f61cea322afde1d6157/hf_xet-1.3.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:df4447f69086dcc6418583315eda6ed09033ac1fbbc784fedcbbbdf67bea1680", size = 3761293, upload-time = "2026-02-24T00:16:06.012Z" },
-    { url = "https://files.pythonhosted.org/packages/97/fd/ebb0ea49e9bd9eb9f52844e417e0e6e9c8a59a1e84790691873fa910adc5/hf_xet-1.3.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:39f4fe714628adc2214ab4a67391182ee751bc4db581868cb3204900817758a8", size = 3523345, upload-time = "2026-02-24T00:16:04.615Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/bb/72ceaaf619cad23d151a281d52e15456bae72f52c3795e820c0b64a5f637/hf_xet-1.3.0-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9b16e53ed6b5c8197cefb3fd12047a430b7034428effed463c03cec68de7e9a3", size = 4178623, upload-time = "2026-02-24T00:15:57.857Z" },
-    { url = "https://files.pythonhosted.org/packages/19/30/3280f4b5e407b442923a80ac0b2d96a65be7494457c55695e63f9a2b33dd/hf_xet-1.3.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:92051a1f73019489be77f6837671024ec785a3d1b888466b09d3a9ea15c4a1b5", size = 3958884, upload-time = "2026-02-24T00:15:56.326Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/13/5174c6d52583e54a761c88570ca657d621ac684747613f47846debfd6d4d/hf_xet-1.3.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:943046b160e7804a85e68a659d2eee1a83ce3661f72d1294d3cc5ece0f45a355", size = 4158146, upload-time = "2026-02-24T00:16:13.158Z" },
-    { url = "https://files.pythonhosted.org/packages/12/13/ea8619021b119e19efdcaeec72f762b5be923cf79b5d4434f2cbbff39829/hf_xet-1.3.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9b798a95d41b4f33b0b455c8aa76ff1fd26a587a4dd3bdec29f0a37c60b78a2f", size = 4395565, upload-time = "2026-02-24T00:16:14.574Z" },
-    { url = "https://files.pythonhosted.org/packages/64/cd/b81d922118a171bfbbecffd60a477e79188ab876260412fac47226a685bf/hf_xet-1.3.0-cp37-abi3-win_amd64.whl", hash = "sha256:227eee5b99d19b9f20c31d901a0c2373af610a24a34e6c2701072c9de48d6d95", size = 3637830, upload-time = "2026-02-24T00:16:22.474Z" },
+    { url = "https://files.pythonhosted.org/packages/05/4b/2351e30dddc6f3b47b3da0a0693ec1e82f8303b1a712faa299cf3552002b/hf_xet-1.4.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:76725fcbc5f59b23ac778f097d3029d6623e3cf6f4057d99d1fce1a7e3cff8fc", size = 3796397, upload-time = "2026-03-11T18:49:47.382Z" },
+    { url = "https://files.pythonhosted.org/packages/48/3d/3db90ec0afb4e26e3330b1346b89fe0e9a3b7bfc2d6a2b2262787790d25f/hf_xet-1.4.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:76f1f73bee81a6e6f608b583908aa24c50004965358ac92c1dc01080a21bcd09", size = 3556235, upload-time = "2026-03-11T18:49:45.785Z" },
+    { url = "https://files.pythonhosted.org/packages/57/6e/2a662af2cbc6c0a64ebe9fcdb8faf05b5205753d45a75a3011bb2209d0b4/hf_xet-1.4.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1818c2e5d6f15354c595d5111c6eb0e5a30a6c5c1a43eeaec20f19607cff0b34", size = 4213145, upload-time = "2026-03-11T18:49:38.009Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/4a/47c129affb540767e0e3e101039a95f4a73a292ec689c26e8f0c5b633f9d/hf_xet-1.4.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:70764d295f485db9cc9a6af76634ea00ec4f96311be7485f8f2b6144739b4ccf", size = 3991951, upload-time = "2026-03-11T18:49:36.396Z" },
+    { url = "https://files.pythonhosted.org/packages/76/81/ec516cfc6281cfeef027b0919166b2fe11ab61fbe6131a2c43fafbed8b68/hf_xet-1.4.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9d3bd2a1e289f772c715ca88cdca8ceb3d8b5c9186534d5925410e531d849a3e", size = 4193205, upload-time = "2026-03-11T18:49:54.415Z" },
+    { url = "https://files.pythonhosted.org/packages/49/48/0945b5e542ed6c6ce758b589b27895a449deab630dfcdee5a6ee0f699d21/hf_xet-1.4.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:06da3797f1fdd9a8f8dbc8c1bddfa0b914789b14580c375d29c32ee35c2c66ca", size = 4431022, upload-time = "2026-03-11T18:49:55.677Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ad/a4859c55ab4b67a4fde2849be8bde81917f54062050419b821071f199a9c/hf_xet-1.4.0-cp313-cp313t-win_amd64.whl", hash = "sha256:30b9d8f384ccec848124d51d883e91f3c88d430589e02a7b6d867730ab8d53ac", size = 3674977, upload-time = "2026-03-11T18:50:06.369Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/17/5bf3791e3a53e597913c2a775a48a98aaded9c2ddb5d1afaedabb55e2ed8/hf_xet-1.4.0-cp313-cp313t-win_arm64.whl", hash = "sha256:07ffdbf7568fa3245b24d949f0f3790b5276fb7293a5554ac4ec02e5f7e2b38d", size = 3536778, upload-time = "2026-03-11T18:50:04.974Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/f9/a0b01945726aea81d2f213457cd5f5102a51e6fd1ca9f9769f561fb57501/hf_xet-1.4.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:981d2b5222c3baadf9567c135cf1d1073786f546b7745686978d46b5df179e16", size = 3799223, upload-time = "2026-03-11T18:49:49.884Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/30/ee62b0c00412f49a7e6f509f0104ee8808692278d247234336df48029349/hf_xet-1.4.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:cc8bd050349d0d7995ce7b3a3a18732a2a8062ce118a82431602088abb373428", size = 3560682, upload-time = "2026-03-11T18:49:48.633Z" },
+    { url = "https://files.pythonhosted.org/packages/93/d0/0fe5c44dbced465a651a03212e1135d0d7f95d19faada692920cb56f8e38/hf_xet-1.4.0-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5d0c38d2a280d814280b8c15eead4a43c9781e7bf6fc37843cffab06dcdc76b9", size = 4218323, upload-time = "2026-03-11T18:49:40.921Z" },
+    { url = "https://files.pythonhosted.org/packages/73/df/7b3c99a4e50442039eae498e5c23db634538eb3e02214109880cf1165d4c/hf_xet-1.4.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6a883f0250682ea888a1bd0af0631feda377e59ad7aae6fb75860ecee7ae0f93", size = 3997156, upload-time = "2026-03-11T18:49:39.634Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/26/47dfedf271c21d95346660ae1698e7ece5ab10791fa6c4f20c59f3713083/hf_xet-1.4.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:99e1d9255fe8ecdf57149bb0543d49e7b7bd8d491ddf431eb57e114253274df5", size = 4199052, upload-time = "2026-03-11T18:49:57.097Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/c0/346b9aad1474e881e65f998d5c1981695f0af045bc7a99204d9d86759a89/hf_xet-1.4.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b25f06ce42bd2d5f2e79d4a2d72f783d3ac91827c80d34a38cf8e5290dd717b0", size = 4434346, upload-time = "2026-03-11T18:49:58.67Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/d6/88ce9d6caa397c3b935263d5bcbe3ebf6c443f7c76098b8c523d206116b9/hf_xet-1.4.0-cp37-abi3-win_amd64.whl", hash = "sha256:8d6d7816d01e0fa33f315c8ca21b05eca0ce4cdc314f13b81d953e46cc6db11d", size = 3678921, upload-time = "2026-03-11T18:50:09.496Z" },
+    { url = "https://files.pythonhosted.org/packages/65/eb/17d99ed253b28a9550ca479867c66a8af4c9bcd8cdc9a26b0c8007c2000a/hf_xet-1.4.0-cp37-abi3-win_arm64.whl", hash = "sha256:cb8d9549122b5b42f34b23b14c6b662a88a586a919d418c774d8dbbc4b3ce2aa", size = 3541054, upload-time = "2026-03-11T18:50:07.963Z" },
 ]
 
 [[package]]
@@ -913,11 +933,11 @@ wheels = [
 
 [[package]]
 name = "isort"
-version = "8.0.0"
+version = "8.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bf/e3/e72b0b3a85f24cf5fc2cd8e92b996592798f896024c5cdf3709232e6e377/isort-8.0.0.tar.gz", hash = "sha256:fddea59202f231e170e52e71e3510b99c373b6e571b55d9c7b31b679c0fed47c", size = 769482, upload-time = "2026-02-19T16:31:59.716Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/ea/cf3aad99dd12c026e2d6835d559efb6fc50ccfd5b46d42d5fec2608b116a/isort-8.0.0-py3-none-any.whl", hash = "sha256:184916a933041c7cf718787f7e52064f3c06272aff69a5cb4dc46497bd8911d9", size = 89715, upload-time = "2026-02-19T16:31:57.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
 ]
 
 [[package]]
@@ -955,75 +975,86 @@ name = "julius"
 version = "0.2.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "torch" },
+    { name = "torch", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/19/c9e1596b5572c786b93428d0904280e964c930fae7e6c9368ed9e1b63922/julius-0.2.7.tar.gz", hash = "sha256:3c0f5f5306d7d6016fcc95196b274cae6f07e2c9596eed314e4e7641554fbb08", size = 59640, upload-time = "2022-09-19T16:13:34.2Z" }
 
 [[package]]
 name = "kiwisolver"
-version = "1.4.9"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/3c/85844f1b0feb11ee581ac23fe5fce65cd049a200c1446708cc1b7f922875/kiwisolver-1.4.9.tar.gz", hash = "sha256:c3b22c26c6fd6811b0ae8363b95ca8ce4ea3c202d3d0975b2914310ceb1bcc4d", size = 97564, upload-time = "2025-08-10T21:27:49.279Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/67/9c61eccb13f0bdca9307614e782fec49ffdde0f7a2314935d489fa93cd9c/kiwisolver-1.5.0.tar.gz", hash = "sha256:d4193f3d9dc3f6f79aaed0e5637f45d98850ebf01f7ca20e69457f3e8946b66a", size = 103482, upload-time = "2026-03-09T13:15:53.382Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/c9/13573a747838aeb1c76e3267620daa054f4152444d1f3d1a2324b78255b5/kiwisolver-1.4.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ac5a486ac389dddcc5bef4f365b6ae3ffff2c433324fb38dd35e3fab7c957999", size = 123686, upload-time = "2025-08-10T21:26:10.034Z" },
-    { url = "https://files.pythonhosted.org/packages/51/ea/2ecf727927f103ffd1739271ca19c424d0e65ea473fbaeea1c014aea93f6/kiwisolver-1.4.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f2ba92255faa7309d06fe44c3a4a97efe1c8d640c2a79a5ef728b685762a6fd2", size = 66460, upload-time = "2025-08-10T21:26:11.083Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/5a/51f5464373ce2aeb5194508298a508b6f21d3867f499556263c64c621914/kiwisolver-1.4.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4a2899935e724dd1074cb568ce7ac0dce28b2cd6ab539c8e001a8578eb106d14", size = 64952, upload-time = "2025-08-10T21:26:12.058Z" },
-    { url = "https://files.pythonhosted.org/packages/70/90/6d240beb0f24b74371762873e9b7f499f1e02166a2d9c5801f4dbf8fa12e/kiwisolver-1.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f6008a4919fdbc0b0097089f67a1eb55d950ed7e90ce2cc3e640abadd2757a04", size = 1474756, upload-time = "2025-08-10T21:26:13.096Z" },
-    { url = "https://files.pythonhosted.org/packages/12/42/f36816eaf465220f683fb711efdd1bbf7a7005a2473d0e4ed421389bd26c/kiwisolver-1.4.9-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:67bb8b474b4181770f926f7b7d2f8c0248cbcb78b660fdd41a47054b28d2a752", size = 1276404, upload-time = "2025-08-10T21:26:14.457Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/64/bc2de94800adc830c476dce44e9b40fd0809cddeef1fde9fcf0f73da301f/kiwisolver-1.4.9-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2327a4a30d3ee07d2fbe2e7933e8a37c591663b96ce42a00bc67461a87d7df77", size = 1294410, upload-time = "2025-08-10T21:26:15.73Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/42/2dc82330a70aa8e55b6d395b11018045e58d0bb00834502bf11509f79091/kiwisolver-1.4.9-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7a08b491ec91b1d5053ac177afe5290adacf1f0f6307d771ccac5de30592d198", size = 1343631, upload-time = "2025-08-10T21:26:17.045Z" },
-    { url = "https://files.pythonhosted.org/packages/22/fd/f4c67a6ed1aab149ec5a8a401c323cee7a1cbe364381bb6c9c0d564e0e20/kiwisolver-1.4.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d8fc5c867c22b828001b6a38d2eaeb88160bf5783c6cb4a5e440efc981ce286d", size = 2224963, upload-time = "2025-08-10T21:26:18.737Z" },
-    { url = "https://files.pythonhosted.org/packages/45/aa/76720bd4cb3713314677d9ec94dcc21ced3f1baf4830adde5bb9b2430a5f/kiwisolver-1.4.9-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:3b3115b2581ea35bb6d1f24a4c90af37e5d9b49dcff267eeed14c3893c5b86ab", size = 2321295, upload-time = "2025-08-10T21:26:20.11Z" },
-    { url = "https://files.pythonhosted.org/packages/80/19/d3ec0d9ab711242f56ae0dc2fc5d70e298bb4a1f9dfab44c027668c673a1/kiwisolver-1.4.9-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:858e4c22fb075920b96a291928cb7dea5644e94c0ee4fcd5af7e865655e4ccf2", size = 2487987, upload-time = "2025-08-10T21:26:21.49Z" },
-    { url = "https://files.pythonhosted.org/packages/39/e9/61e4813b2c97e86b6fdbd4dd824bf72d28bcd8d4849b8084a357bc0dd64d/kiwisolver-1.4.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ed0fecd28cc62c54b262e3736f8bb2512d8dcfdc2bcf08be5f47f96bf405b145", size = 2291817, upload-time = "2025-08-10T21:26:22.812Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/41/85d82b0291db7504da3c2defe35c9a8a5c9803a730f297bd823d11d5fb77/kiwisolver-1.4.9-cp312-cp312-win_amd64.whl", hash = "sha256:f68208a520c3d86ea51acf688a3e3002615a7f0238002cccc17affecc86a8a54", size = 73895, upload-time = "2025-08-10T21:26:24.37Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/92/5f3068cf15ee5cb624a0c7596e67e2a0bb2adee33f71c379054a491d07da/kiwisolver-1.4.9-cp312-cp312-win_arm64.whl", hash = "sha256:2c1a4f57df73965f3f14df20b80ee29e6a7930a57d2d9e8491a25f676e197c60", size = 64992, upload-time = "2025-08-10T21:26:25.732Z" },
-    { url = "https://files.pythonhosted.org/packages/31/c1/c2686cda909742ab66c7388e9a1a8521a59eb89f8bcfbee28fc980d07e24/kiwisolver-1.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a5d0432ccf1c7ab14f9949eec60c5d1f924f17c037e9f8b33352fa05799359b8", size = 123681, upload-time = "2025-08-10T21:26:26.725Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/f0/f44f50c9f5b1a1860261092e3bc91ecdc9acda848a8b8c6abfda4a24dd5c/kiwisolver-1.4.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efb3a45b35622bb6c16dbfab491a8f5a391fe0e9d45ef32f4df85658232ca0e2", size = 66464, upload-time = "2025-08-10T21:26:27.733Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/7a/9d90a151f558e29c3936b8a47ac770235f436f2120aca41a6d5f3d62ae8d/kiwisolver-1.4.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1a12cf6398e8a0a001a059747a1cbf24705e18fe413bc22de7b3d15c67cffe3f", size = 64961, upload-time = "2025-08-10T21:26:28.729Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/e9/f218a2cb3a9ffbe324ca29a9e399fa2d2866d7f348ec3a88df87fc248fc5/kiwisolver-1.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b67e6efbf68e077dd71d1a6b37e43e1a99d0bff1a3d51867d45ee8908b931098", size = 1474607, upload-time = "2025-08-10T21:26:29.798Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/28/aac26d4c882f14de59041636292bc838db8961373825df23b8eeb807e198/kiwisolver-1.4.9-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5656aa670507437af0207645273ccdfee4f14bacd7f7c67a4306d0dcaeaf6eed", size = 1276546, upload-time = "2025-08-10T21:26:31.401Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/ad/8bfc1c93d4cc565e5069162f610ba2f48ff39b7de4b5b8d93f69f30c4bed/kiwisolver-1.4.9-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bfc08add558155345129c7803b3671cf195e6a56e7a12f3dde7c57d9b417f525", size = 1294482, upload-time = "2025-08-10T21:26:32.721Z" },
-    { url = "https://files.pythonhosted.org/packages/da/f1/6aca55ff798901d8ce403206d00e033191f63d82dd708a186e0ed2067e9c/kiwisolver-1.4.9-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:40092754720b174e6ccf9e845d0d8c7d8e12c3d71e7fc35f55f3813e96376f78", size = 1343720, upload-time = "2025-08-10T21:26:34.032Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/91/eed031876c595c81d90d0f6fc681ece250e14bf6998c3d7c419466b523b7/kiwisolver-1.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:497d05f29a1300d14e02e6441cf0f5ee81c1ff5a304b0d9fb77423974684e08b", size = 2224907, upload-time = "2025-08-10T21:26:35.824Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/ec/4d1925f2e49617b9cca9c34bfa11adefad49d00db038e692a559454dfb2e/kiwisolver-1.4.9-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:bdd1a81a1860476eb41ac4bc1e07b3f07259e6d55bbf739b79c8aaedcf512799", size = 2321334, upload-time = "2025-08-10T21:26:37.534Z" },
-    { url = "https://files.pythonhosted.org/packages/43/cb/450cd4499356f68802750c6ddc18647b8ea01ffa28f50d20598e0befe6e9/kiwisolver-1.4.9-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:e6b93f13371d341afee3be9f7c5964e3fe61d5fa30f6a30eb49856935dfe4fc3", size = 2488313, upload-time = "2025-08-10T21:26:39.191Z" },
-    { url = "https://files.pythonhosted.org/packages/71/67/fc76242bd99f885651128a5d4fa6083e5524694b7c88b489b1b55fdc491d/kiwisolver-1.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d75aa530ccfaa593da12834b86a0724f58bff12706659baa9227c2ccaa06264c", size = 2291970, upload-time = "2025-08-10T21:26:40.828Z" },
-    { url = "https://files.pythonhosted.org/packages/75/bd/f1a5d894000941739f2ae1b65a32892349423ad49c2e6d0771d0bad3fae4/kiwisolver-1.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:dd0a578400839256df88c16abddf9ba14813ec5f21362e1fe65022e00c883d4d", size = 73894, upload-time = "2025-08-10T21:26:42.33Z" },
-    { url = "https://files.pythonhosted.org/packages/95/38/dce480814d25b99a391abbddadc78f7c117c6da34be68ca8b02d5848b424/kiwisolver-1.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:d4188e73af84ca82468f09cadc5ac4db578109e52acb4518d8154698d3a87ca2", size = 64995, upload-time = "2025-08-10T21:26:43.889Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/37/7d218ce5d92dadc5ebdd9070d903e0c7cf7edfe03f179433ac4d13ce659c/kiwisolver-1.4.9-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:5a0f2724dfd4e3b3ac5a82436a8e6fd16baa7d507117e4279b660fe8ca38a3a1", size = 126510, upload-time = "2025-08-10T21:26:44.915Z" },
-    { url = "https://files.pythonhosted.org/packages/23/b0/e85a2b48233daef4b648fb657ebbb6f8367696a2d9548a00b4ee0eb67803/kiwisolver-1.4.9-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:1b11d6a633e4ed84fc0ddafd4ebfd8ea49b3f25082c04ad12b8315c11d504dc1", size = 67903, upload-time = "2025-08-10T21:26:45.934Z" },
-    { url = "https://files.pythonhosted.org/packages/44/98/f2425bc0113ad7de24da6bb4dae1343476e95e1d738be7c04d31a5d037fd/kiwisolver-1.4.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:61874cdb0a36016354853593cffc38e56fc9ca5aa97d2c05d3dcf6922cd55a11", size = 66402, upload-time = "2025-08-10T21:26:47.101Z" },
-    { url = "https://files.pythonhosted.org/packages/98/d8/594657886df9f34c4177cc353cc28ca7e6e5eb562d37ccc233bff43bbe2a/kiwisolver-1.4.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:60c439763a969a6af93b4881db0eed8fadf93ee98e18cbc35bc8da868d0c4f0c", size = 1582135, upload-time = "2025-08-10T21:26:48.665Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/c6/38a115b7170f8b306fc929e166340c24958347308ea3012c2b44e7e295db/kiwisolver-1.4.9-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92a2f997387a1b79a75e7803aa7ded2cfbe2823852ccf1ba3bcf613b62ae3197", size = 1389409, upload-time = "2025-08-10T21:26:50.335Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/3b/e04883dace81f24a568bcee6eb3001da4ba05114afa622ec9b6fafdc1f5e/kiwisolver-1.4.9-cp313-cp313t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a31d512c812daea6d8b3be3b2bfcbeb091dbb09177706569bcfc6240dcf8b41c", size = 1401763, upload-time = "2025-08-10T21:26:51.867Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/80/20ace48e33408947af49d7d15c341eaee69e4e0304aab4b7660e234d6288/kiwisolver-1.4.9-cp313-cp313t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:52a15b0f35dad39862d376df10c5230155243a2c1a436e39eb55623ccbd68185", size = 1453643, upload-time = "2025-08-10T21:26:53.592Z" },
-    { url = "https://files.pythonhosted.org/packages/64/31/6ce4380a4cd1f515bdda976a1e90e547ccd47b67a1546d63884463c92ca9/kiwisolver-1.4.9-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a30fd6fdef1430fd9e1ba7b3398b5ee4e2887783917a687d86ba69985fb08748", size = 2330818, upload-time = "2025-08-10T21:26:55.051Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/e9/3f3fcba3bcc7432c795b82646306e822f3fd74df0ee81f0fa067a1f95668/kiwisolver-1.4.9-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:cc9617b46837c6468197b5945e196ee9ca43057bb7d9d1ae688101e4e1dddf64", size = 2419963, upload-time = "2025-08-10T21:26:56.421Z" },
-    { url = "https://files.pythonhosted.org/packages/99/43/7320c50e4133575c66e9f7dadead35ab22d7c012a3b09bb35647792b2a6d/kiwisolver-1.4.9-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:0ab74e19f6a2b027ea4f845a78827969af45ce790e6cb3e1ebab71bdf9f215ff", size = 2594639, upload-time = "2025-08-10T21:26:57.882Z" },
-    { url = "https://files.pythonhosted.org/packages/65/d6/17ae4a270d4a987ef8a385b906d2bdfc9fce502d6dc0d3aea865b47f548c/kiwisolver-1.4.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dba5ee5d3981160c28d5490f0d1b7ed730c22470ff7f6cc26cfcfaacb9896a07", size = 2391741, upload-time = "2025-08-10T21:26:59.237Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/8f/8f6f491d595a9e5912971f3f863d81baddccc8a4d0c3749d6a0dd9ffc9df/kiwisolver-1.4.9-cp313-cp313t-win_arm64.whl", hash = "sha256:0749fd8f4218ad2e851e11cc4dc05c7cbc0cbc4267bdfdb31782e65aace4ee9c", size = 68646, upload-time = "2025-08-10T21:27:00.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/b2/818b74ebea34dabe6d0c51cb1c572e046730e64844da6ed646d5298c40ce/kiwisolver-1.5.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4e9750bc21b886308024f8a54ccb9a2cc38ac9fa813bf4348434e3d54f337ff9", size = 123158, upload-time = "2026-03-09T13:13:23.127Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/d9/405320f8077e8e1c5c4bd6adc45e1e6edf6d727b6da7f2e2533cf58bff71/kiwisolver-1.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:72ec46b7eba5b395e0a7b63025490d3214c11013f4aacb4f5e8d6c3041829588", size = 66388, upload-time = "2026-03-09T13:13:24.765Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9f/795fedf35634f746151ca8839d05681ceb6287fbed6cc1c9bf235f7887c2/kiwisolver-1.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ed3a984b31da7481b103f68776f7128a89ef26ed40f4dc41a2223cda7fb24819", size = 64068, upload-time = "2026-03-09T13:13:25.878Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/13/680c54afe3e65767bed7ec1a15571e1a2f1257128733851ade24abcefbcc/kiwisolver-1.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bb5136fb5352d3f422df33f0c879a1b0c204004324150cc3b5e3c4f310c9049f", size = 1477934, upload-time = "2026-03-09T13:13:27.166Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2f/cebfcdb60fd6a9b0f6b47a9337198bcbad6fbe15e68189b7011fd914911f/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b2af221f268f5af85e776a73d62b0845fc8baf8ef0abfae79d29c77d0e776aaf", size = 1278537, upload-time = "2026-03-09T13:13:28.707Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/0d/9b782923aada3fafb1d6b84e13121954515c669b18af0c26e7d21f579855/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b0f172dc8ffaccb8522d7c5d899de00133f2f1ca7b0a49b7da98e901de87bf2d", size = 1296685, upload-time = "2026-03-09T13:13:30.528Z" },
+    { url = "https://files.pythonhosted.org/packages/27/70/83241b6634b04fe44e892688d5208332bde130f38e610c0418f9ede47ded/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6ab8ba9152203feec73758dad83af9a0bbe05001eb4639e547207c40cfb52083", size = 1346024, upload-time = "2026-03-09T13:13:32.818Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/db/30ed226fb271ae1a6431fc0fe0edffb2efe23cadb01e798caeb9f2ceae8f/kiwisolver-1.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:cdee07c4d7f6d72008d3f73b9bf027f4e11550224c7c50d8df1ae4a37c1402a6", size = 987241, upload-time = "2026-03-09T13:13:34.435Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bd/c314595208e4c9587652d50959ead9e461995389664e490f4dce7ff0f782/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7c60d3c9b06fb23bd9c6139281ccbdc384297579ae037f08ae90c69f6845c0b1", size = 2227742, upload-time = "2026-03-09T13:13:36.4Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/43/0499cec932d935229b5543d073c2b87c9c22846aab48881e9d8d6e742a2d/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:e315e5ec90d88e140f57696ff85b484ff68bb311e36f2c414aa4286293e6dee0", size = 2323966, upload-time = "2026-03-09T13:13:38.204Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6f/79b0d760907965acfd9d61826a3d41f8f093c538f55cd2633d3f0db269f6/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1465387ac63576c3e125e5337a6892b9e99e0627d52317f3ca79e6930d889d15", size = 1977417, upload-time = "2026-03-09T13:13:39.966Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/31/01d0537c41cb75a551a438c3c7a80d0c60d60b81f694dac83dd436aec0d0/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:530a3fd64c87cffa844d4b6b9768774763d9caa299e9b75d8eca6a4423b31314", size = 2491238, upload-time = "2026-03-09T13:13:41.698Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/34/8aefdd0be9cfd00a44509251ba864f5caf2991e36772e61c408007e7f417/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1d9daea4ea6b9be74fe2f01f7fbade8d6ffab263e781274cffca0dba9be9eec9", size = 2294947, upload-time = "2026-03-09T13:13:43.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/cf/0348374369ca588f8fe9c338fae49fa4e16eeb10ffb3d012f23a54578a9e/kiwisolver-1.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:f18c2d9782259a6dc132fdc7a63c168cbc74b35284b6d75c673958982a378384", size = 73569, upload-time = "2026-03-09T13:13:45.792Z" },
+    { url = "https://files.pythonhosted.org/packages/28/26/192b26196e2316e2bd29deef67e37cdf9870d9af8e085e521afff0fed526/kiwisolver-1.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:f7c7553b13f69c1b29a5bde08ddc6d9d0c8bfb84f9ed01c30db25944aeb852a7", size = 64997, upload-time = "2026-03-09T13:13:46.878Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/69/024d6711d5ba575aa65d5538042e99964104e97fa153a9f10bc369182bc2/kiwisolver-1.5.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:fd40bb9cd0891c4c3cb1ddf83f8bbfa15731a248fdc8162669405451e2724b09", size = 123166, upload-time = "2026-03-09T13:13:48.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/adbb40df306f587054a348831220812b9b1d787aff714cfbc8556e38fccd/kiwisolver-1.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c0e1403fd7c26d77c1f03e096dc58a5c726503fa0db0456678b8668f76f521e3", size = 66395, upload-time = "2026-03-09T13:13:49.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3a/d0a972b34e1c63e2409413104216cd1caa02c5a37cb668d1687d466c1c45/kiwisolver-1.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dda366d548e89a90d88a86c692377d18d8bd64b39c1fb2b92cb31370e2896bbd", size = 64065, upload-time = "2026-03-09T13:13:50.562Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0a/7b98e1e119878a27ba8618ca1e18b14f992ff1eda40f47bccccf4de44121/kiwisolver-1.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:332b4f0145c30b5f5ad9374881133e5aa64320428a57c2c2b61e9d891a51c2f3", size = 1477903, upload-time = "2026-03-09T13:13:52.084Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d8/55638d89ffd27799d5cc3d8aa28e12f4ce7a64d67b285114dbedc8ea4136/kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c50b89ffd3e1a911c69a1dd3de7173c0cd10b130f56222e57898683841e4f96", size = 1278751, upload-time = "2026-03-09T13:13:54.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/97/b4c8d0d18421ecceba20ad8701358453b88e32414e6f6950b5a4bad54e65/kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4db576bb8c3ef9365f8b40fe0f671644de6736ae2c27a2c62d7d8a1b4329f099", size = 1296793, upload-time = "2026-03-09T13:13:56.287Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/10/f862f94b6389d8957448ec9df59450b81bec4abb318805375c401a1e6892/kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0b85aad90cea8ac6797a53b5d5f2e967334fa4d1149f031c4537569972596cb8", size = 1346041, upload-time = "2026-03-09T13:13:58.269Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/6a/f1650af35821eaf09de398ec0bc2aefc8f211f0cda50204c9f1673741ba9/kiwisolver-1.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:d36ca54cb4c6c4686f7cbb7b817f66f5911c12ddb519450bbe86707155028f87", size = 987292, upload-time = "2026-03-09T13:13:59.871Z" },
+    { url = "https://files.pythonhosted.org/packages/de/19/d7fb82984b9238115fe629c915007be608ebd23dc8629703d917dbfaffd4/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:38f4a703656f493b0ad185211ccfca7f0386120f022066b018eb5296d8613e23", size = 2227865, upload-time = "2026-03-09T13:14:01.401Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/b9/46b7f386589fd222dac9e9de9c956ce5bcefe2ee73b4e79891381dda8654/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3ac2360e93cb41be81121755c6462cff3beaa9967188c866e5fce5cf13170859", size = 2324369, upload-time = "2026-03-09T13:14:02.972Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8b/95e237cf3d9c642960153c769ddcbe278f182c8affb20cecc1cc983e7cc5/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c95cab08d1965db3d84a121f1c7ce7479bdd4072c9b3dafd8fecce48a2e6b902", size = 1977989, upload-time = "2026-03-09T13:14:04.503Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/95/980c9df53501892784997820136c01f62bc1865e31b82b9560f980c0e649/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fc20894c3d21194d8041a28b65622d5b86db786da6e3cfe73f0c762951a61167", size = 2491645, upload-time = "2026-03-09T13:14:06.106Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/900647fd0840abebe1561792c6b31e6a7c0e278fc3973d30572a965ca14c/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7a32f72973f0f950c1920475d5c5ea3d971b81b6f0ec53b8d0a956cc965f22e0", size = 2295237, upload-time = "2026-03-09T13:14:08.891Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8a/be60e3bbcf513cc5a50f4a3e88e1dcecebb79c1ad607a7222877becaa101/kiwisolver-1.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:0bf3acf1419fa93064a4c2189ac0b58e3be7872bf6ee6177b0d4c63dc4cea276", size = 73573, upload-time = "2026-03-09T13:14:12.327Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/d2/64be2e429eb4fca7f7e1c52a91b12663aeaf25de3895e5cca0f47ef2a8d0/kiwisolver-1.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:fa8eb9ecdb7efb0b226acec134e0d709e87a909fa4971a54c0c4f6e88635484c", size = 64998, upload-time = "2026-03-09T13:14:13.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/69/ce68dd0c85755ae2de490bf015b62f2cea5f6b14ff00a463f9d0774449ff/kiwisolver-1.5.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db485b3847d182b908b483b2ed133c66d88d49cacf98fd278fadafe11b4478d1", size = 125700, upload-time = "2026-03-09T13:14:14.636Z" },
+    { url = "https://files.pythonhosted.org/packages/74/aa/937aac021cf9d4349990d47eb319309a51355ed1dbdc9c077cdc9224cb11/kiwisolver-1.5.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:be12f931839a3bdfe28b584db0e640a65a8bcbc24560ae3fdb025a449b3d754e", size = 67537, upload-time = "2026-03-09T13:14:15.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/20/3a87fbece2c40ad0f6f0aefa93542559159c5f99831d596050e8afae7a9f/kiwisolver-1.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:16b85d37c2cbb3253226d26e64663f755d88a03439a9c47df6246b35defbdfb7", size = 65514, upload-time = "2026-03-09T13:14:18.035Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7f/f943879cda9007c45e1f7dba216d705c3a18d6b35830e488b6c6a4e7cdf0/kiwisolver-1.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4432b835675f0ea7414aab3d37d119f7226d24869b7a829caeab49ebda407b0c", size = 1584848, upload-time = "2026-03-09T13:14:19.745Z" },
+    { url = "https://files.pythonhosted.org/packages/37/f8/4d4f85cc1870c127c88d950913370dd76138482161cd07eabbc450deff01/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b0feb50971481a2cc44d94e88bdb02cdd497618252ae226b8eb1201b957e368", size = 1391542, upload-time = "2026-03-09T13:14:21.54Z" },
+    { url = "https://files.pythonhosted.org/packages/04/0b/65dd2916c84d252b244bd405303220f729e7c17c9d7d33dca6feeff9ffc4/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:56fa888f10d0f367155e76ce849fa1166fc9730d13bd2d65a2aa13b6f5424489", size = 1404447, upload-time = "2026-03-09T13:14:23.205Z" },
+    { url = "https://files.pythonhosted.org/packages/39/5c/2606a373247babce9b1d056c03a04b65f3cf5290a8eac5d7bdead0a17e21/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:940dda65d5e764406b9fb92761cbf462e4e63f712ab60ed98f70552e496f3bf1", size = 1455918, upload-time = "2026-03-09T13:14:24.74Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d1/c6078b5756670658e9192a2ef11e939c92918833d2745f85cd14a6004bdf/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_39_riscv64.whl", hash = "sha256:89fc958c702ee9a745e4700378f5d23fddbc46ff89e8fdbf5395c24d5c1452a3", size = 1072856, upload-time = "2026-03-09T13:14:26.597Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c8/7def6ddf16eb2b3741d8b172bdaa9af882b03c78e9b0772975408801fa63/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9027d773c4ff81487181a925945743413f6069634d0b122d0b37684ccf4f1e18", size = 2333580, upload-time = "2026-03-09T13:14:28.237Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/87/2ac1fce0eb1e616fcd3c35caa23e665e9b1948bb984f4764790924594128/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5b233ea3e165e43e35dba1d2b8ecc21cf070b45b65ae17dd2747d2713d942021", size = 2423018, upload-time = "2026-03-09T13:14:30.018Z" },
+    { url = "https://files.pythonhosted.org/packages/67/13/c6700ccc6cc218716bfcda4935e4b2997039869b4ad8a94f364c5a3b8e63/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ce9bf03dad3b46408c08649c6fbd6ca28a9fce0eb32fdfffa6775a13103b5310", size = 2062804, upload-time = "2026-03-09T13:14:32.888Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bd/877056304626943ff0f1f44c08f584300c199b887cb3176cd7e34f1515f1/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:fc4d3f1fb9ca0ae9f97b095963bc6326f1dbfd3779d6679a1e016b9baaa153d3", size = 2597482, upload-time = "2026-03-09T13:14:34.971Z" },
+    { url = "https://files.pythonhosted.org/packages/75/19/c60626c47bf0f8ac5dcf72c6c98e266d714f2fbbfd50cf6dab5ede3aaa50/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f443b4825c50a51ee68585522ab4a1d1257fac65896f282b4c6763337ac9f5d2", size = 2394328, upload-time = "2026-03-09T13:14:36.816Z" },
+    { url = "https://files.pythonhosted.org/packages/47/84/6a6d5e5bb8273756c27b7d810d47f7ef2f1f9b9fd23c9ee9a3f8c75c9cef/kiwisolver-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:893ff3a711d1b515ba9da14ee090519bad4610ed1962fbe298a434e8c5f8db53", size = 68410, upload-time = "2026-03-09T13:14:38.695Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/fa/2910df836372d8761bb6eff7d8bdcb1613b5c2e03f260efe7abe34d388a7/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_10_13_x86_64.whl", hash = "sha256:5ae8e62c147495b01a0f4765c878e9bfdf843412446a247e28df59936e99e797", size = 130262, upload-time = "2026-03-09T13:15:35.629Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/41/c5f71f9f00aabcc71fee8b7475e3f64747282580c2fe748961ba29b18385/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f6764a4ccab3078db14a632420930f6186058750df066b8ea2a7106df91d3203", size = 138036, upload-time = "2026-03-09T13:15:36.894Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/06/7399a607f434119c6e1fdc8ec89a8d51ccccadf3341dee4ead6bd14caaf5/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c31c13da98624f957b0fb1b5bae5383b2333c2c3f6793d9825dd5ce79b525cb7", size = 194295, upload-time = "2026-03-09T13:15:38.22Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/91/53255615acd2a1eaca307ede3c90eb550bae9c94581f8c00081b6b1c8f44/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:1f1489f769582498610e015a8ef2d36f28f505ab3096d0e16b4858a9ec214f57", size = 75987, upload-time = "2026-03-09T13:15:39.65Z" },
 ]
 
 [[package]]
 name = "lameenc"
-version = "1.8.1"
+version = "1.8.2"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/87/25e9619de89b64e9c66c5205a8de15671ee0e129b2e045c23c1f98fd9ec6/lameenc-1.8.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ef7d7ccad32f5febd812fb078fe63e46b4ec411d2ef612a79fd0391ef9f65b35", size = 193831, upload-time = "2025-01-01T22:08:42.652Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/43/d17cd461a1bdc29661739350f04c0a7e12b11241a975662b8c6578d27f82/lameenc-1.8.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c980a676314d3c344f080be8ef05c98d60d201da6a492c3658c6bf5a733a1e11", size = 182214, upload-time = "2025-01-01T22:19:40.067Z" },
-    { url = "https://files.pythonhosted.org/packages/61/49/b749718d6deaebb6d653f292599560b52df27a6709c25e8f0e4e7b4d4e6f/lameenc-1.8.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a86f51bc50421db8e122c627bc2d0e7526da4505ebb6699c20c8b7352cb8df19", size = 253358, upload-time = "2025-01-01T22:16:39.909Z" },
-    { url = "https://files.pythonhosted.org/packages/46/19/6aa2313271b4635572c353b1b64c5612efedf0373ab0e0061bb5d916d8e5/lameenc-1.8.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:693a6cb42494dde1ae78756f1323b07dea041a152a1f4805639490bfea0e9ba3", size = 249108, upload-time = "2025-01-01T22:05:50.037Z" },
-    { url = "https://files.pythonhosted.org/packages/75/f5/bd86cfe4cf44e583c14722164e621336a02cbe26645e3be1d8b874bf8b81/lameenc-1.8.1-cp312-cp312-win32.whl", hash = "sha256:26720094ed7cb9f3364f79fdc7ad3459aabb71b94f30936dfe0ad7430078af07", size = 125452, upload-time = "2025-01-01T22:07:31.84Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/c6/919e890cc135d590dc3b041414ef5a94997f3bc2f614afa16b7c2f0f73ee/lameenc-1.8.1-cp312-cp312-win_amd64.whl", hash = "sha256:715e0e72ed5429f00042379e48a7903e54ee5dc01069db34338536f3595059c3", size = 152019, upload-time = "2025-01-01T22:07:33.231Z" },
-    { url = "https://files.pythonhosted.org/packages/41/7d/87eb694ec04e87f49c059f4f40c2bc3543a419d9aee258efc4941ef9b888/lameenc-1.8.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1ef8f8ad8de7a038aa0624efc6c585ad600c7e6d34acc2583631883027bd6752", size = 193822, upload-time = "2025-01-01T22:08:41.966Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/99/d7442223a955295543fdeafd8a61058a323b577bfe77ef57915d8d3bb2aa/lameenc-1.8.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e4bf9c20e41a66964ff5c2f0ab3072cd39df9fc19ecc419ad8ef0c9bb1e80ac1", size = 182221, upload-time = "2025-01-01T22:08:41.967Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/b9/fc5e11043cdfcddbb1c7c15d570c6285a6e46a9ae7a80caed017c93cbd86/lameenc-1.8.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b6b4f4318e43314da20caad14c0d884546e90abdd4c7fe884c6558db355c8efb", size = 253424, upload-time = "2025-01-01T22:16:42.564Z" },
-    { url = "https://files.pythonhosted.org/packages/05/f2/ad9616f1dfd8ae156325720e11792eceedd5adadc9300d3694a4be28ba98/lameenc-1.8.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0399f7dec7c8d626c913023a3c7cbd89314dab6f0e67ac4a335a4a4cb8c23de3", size = 249158, upload-time = "2025-01-01T22:05:52.007Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/55/46406f014302b540b76ed4a83a16e2f58f53770a0109dcacb42acd535625/lameenc-1.8.1-cp313-cp313-win32.whl", hash = "sha256:d765b3b20baedc87286e199554975074f9f9799a13b6bddb88baae0f3aeb8904", size = 125450, upload-time = "2025-01-01T22:07:30.937Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/70/5138ee0007ca06109e6697bd2eb77f9211374f49b226c04ca08cb110fd6b/lameenc-1.8.1-cp313-cp313-win_amd64.whl", hash = "sha256:c5fa96b300d27785c3110f566961bd97487c98023ee88d0822ca7c9af0fd9b89", size = 152020, upload-time = "2025-01-01T22:07:33.158Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/dc/a150418d932f2e2e2eedece0f62c43aa973b08a48e257b382f970887dd59/lameenc-1.8.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ca88a3ac5848b3ade75777288c309b2db18fa0788c140811b3852533d9dc291", size = 255301, upload-time = "2025-01-01T22:16:45.182Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/52/f5f2d979372f3718e2792e8c3390f9eb89bc836eb484c85110c3333c9813/lameenc-1.8.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:68dbacf39fc049dae22b08614d363d3293822d7255908b1bfe50d51c1a0fd6a1", size = 250524, upload-time = "2025-01-01T22:05:54.613Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/0e/4cbbaa655bdb3e8a2d8e58ea80537f78d65d2d1423ca2e138a16a2bd9065/lameenc-1.8.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:18a6e6e0ed6759eb952e76dbe1f2d246768f2b79ca2e6154a1ef5d0058091633", size = 191499, upload-time = "2026-03-07T19:56:53.371Z" },
+    { url = "https://files.pythonhosted.org/packages/81/08/39f80baadbc44541edb8ed2df4e3a6bb35efa6a444b55bda8003f849c46c/lameenc-1.8.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c0a8efacaca2f7f3e32e59fdc2668b41443adfa7285774f1e0e61611d0fade74", size = 180079, upload-time = "2026-03-07T19:56:59.276Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/d8/bca20935531b96cd9b177251847af804f0072a068302d3dcacbf5e686637/lameenc-1.8.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:674dfd584ca4988b713266e24bfd0aaa245102f171aa7dbead21e6638dadca6e", size = 253451, upload-time = "2026-03-07T20:08:40.709Z" },
+    { url = "https://files.pythonhosted.org/packages/45/36/01f9f222354f7493f17bd135610170a4db1f06abef58b3776e6033a09472/lameenc-1.8.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3564d4068d3344bea35223ea7367c80bb47d09c98e0598f02df1839538ed64c5", size = 249285, upload-time = "2026-03-07T19:56:20.092Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e4/c6c8aa6c0a7e8770bd1401d5a96b7570916c8024a5e2d253b4a83107dbc3/lameenc-1.8.2-cp312-cp312-win32.whl", hash = "sha256:d34ce1df348e8e7dee509f73ec8b80be066ff97b322a26d057a706b8d5eb137d", size = 126588, upload-time = "2026-03-07T19:57:28.456Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b5/be173d750ca85fbd5f38153106bd2673ec0540ca4b6eb22e742520dadd7d/lameenc-1.8.2-cp312-cp312-win_amd64.whl", hash = "sha256:551ee0aa69bbe995a3cf001da7c563040f35dab4308cb33b077daf6aaa823a78", size = 154843, upload-time = "2026-03-07T19:57:29.03Z" },
+    { url = "https://files.pythonhosted.org/packages/87/f1/1c99c6bb87d5c07be41364efcba60c896a9f5118a9647ab65ff6182389b3/lameenc-1.8.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9fcfb12b4437c569e5977a57bf57b38bf95be1720a237337ffd18909e5f5b983", size = 191495, upload-time = "2026-03-07T19:56:47.836Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/0d/3b3c39d7cdc5996e84644ea39d551a1d4368ebd61e902ccc51d1b7027977/lameenc-1.8.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f83eb429725dc411db00bd17cc2c3f5304f419775db8693d96abea0bc8a59b85", size = 180075, upload-time = "2026-03-07T19:56:55.94Z" },
+    { url = "https://files.pythonhosted.org/packages/de/6b/8724a3a518ebd734439076cce1ee175538bd76f8f43232c3527b2db499a6/lameenc-1.8.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1481ae0c2b7f36b7d2509b0b924e6e717cb672b601e6716e0b5d9e51d08bb3cd", size = 253510, upload-time = "2026-03-07T20:08:41.92Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/46/5f7748110f920c1daf951ca07062987d5e5915aae6ca56eaddec2f948a41/lameenc-1.8.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:825ca907bbc36dc0a86a982835cdc9471597ca5874aae437cc411fc256f566e5", size = 249348, upload-time = "2026-03-07T19:56:25.708Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/ff/085bf42e88afc054cca925d711c3714c5d41d8e8dd49b9b2b89ba2c1c2c6/lameenc-1.8.2-cp313-cp313-win32.whl", hash = "sha256:73fd88f0ca19cfdb24d3bd9650a29cf252018d36265bf281c3060a01d83940e9", size = 126585, upload-time = "2026-03-07T19:57:29.763Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d7/c6e6f8428a1c95080b54fa47362c79fa35485e1b2f4dd361b9c0a838d56b/lameenc-1.8.2-cp313-cp313-win_amd64.whl", hash = "sha256:4b81a04cd7daa8db1c82d4496ae5be888647c2ea672706aeba89c7c72b1d45c4", size = 154838, upload-time = "2026-03-07T19:57:24.582Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/3a/8698832d0a2c2a8a15fd98db385c41952b37dbe71849c09f0d274bbd19f6/lameenc-1.8.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f6479246684707b9c548155d6a526a38e2a0408c0a04dac9658d3745e622263", size = 255380, upload-time = "2026-03-07T20:08:43.098Z" },
+    { url = "https://files.pythonhosted.org/packages/76/db/edc9d742661871bf0ae841426f437e1c890a8828a5d1c0eb5b3680fb9811/lameenc-1.8.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74f985e5b198385f13f451a3c3e101b1de1996348149deed5c7b8d212b6049a1", size = 250703, upload-time = "2026-03-07T19:56:28.105Z" },
 ]
 
 [[package]]
@@ -1049,14 +1080,14 @@ wheels = [
 
 [[package]]
 name = "lazy-loader"
-version = "0.4"
+version = "0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6b/c875b30a1ba490860c93da4cabf479e03f584eba06fe5963f6f6644653d8/lazy_loader-0.4.tar.gz", hash = "sha256:47c75182589b91a4e1a85a136c074285a5ad4d9f39c63e0d7fb76391c4574cd1", size = 15431, upload-time = "2024-04-05T13:03:12.261Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/ac/21a1f8aa3777f5658576777ea76bfb124b702c520bbe90edf4ae9915eafa/lazy_loader-0.5.tar.gz", hash = "sha256:717f9179a0dbed357012ddad50a5ad3d5e4d9a0b8712680d4e687f5e6e6ed9b3", size = 15294, upload-time = "2026-03-06T15:45:09.054Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/60/d497a310bde3f01cb805196ac61b7ad6dc5dcf8dce66634dc34364b20b4f/lazy_loader-0.4-py3-none-any.whl", hash = "sha256:342aa8e14d543a154047afb4ba8ef17f5563baad3fc610d7b15b213b0f119efc", size = 12097, upload-time = "2024-04-05T13:03:10.514Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl", hash = "sha256:ab0ea149e9c554d4ffeeb21105ac60bed7f3b4fd69b1d2360a4add51b170b005", size = 8044, upload-time = "2026-03-06T15:45:07.668Z" },
 ]
 
 [[package]]
@@ -1139,7 +1170,8 @@ dependencies = [
     { name = "packaging" },
     { name = "pytorch-lightning" },
     { name = "pyyaml" },
-    { name = "torch" },
+    { name = "torch", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
     { name = "torchmetrics" },
     { name = "tqdm" },
     { name = "typing-extensions" },
@@ -1192,34 +1224,34 @@ wheels = [
 
 [[package]]
 name = "marisa-trie"
-version = "1.3.1"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c5/e3/c9066e74076b90f9701ccd23d6a0b8c1d583feefdec576dc3e1bb093c50d/marisa_trie-1.3.1.tar.gz", hash = "sha256:97107fd12f30e4f8fea97790343a2d2d9a79d93697fe14e1b6f6363c984ff85b", size = 212454, upload-time = "2025-08-26T15:13:18.401Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/d0/048804753e2e5f12dd426e8badaa4a938a085cf00316df092b619863bef0/marisa_trie-1.4.0.tar.gz", hash = "sha256:20dd1a9035c5cb225c6eeb8e516ebced9497bf0b48d60e9b556f38d8cdf76df8", size = 261541, upload-time = "2026-03-10T15:27:43.327Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/40/ee7ea61b88d62d2189b5c4a27bc0fc8d9c32f8b8dc6daf1c93a7b7ad34ac/marisa_trie-1.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5b7c1e7fa6c3b855e8cfbabf38454d7decbaba1c567d0cd58880d033c6b363bd", size = 173454, upload-time = "2025-08-26T15:12:12.13Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/fc/58635811586898041004b2197a085253706ede211324a53ec01612a50e20/marisa_trie-1.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c12b44c190deb0d67655021da1f2d0a7d61a257bf844101cf982e68ed344f28d", size = 155305, upload-time = "2025-08-26T15:12:13.374Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/98/88ca0c98d37034a3237acaf461d210cbcfeb6687929e5ba0e354971fa3ed/marisa_trie-1.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9688c7b45f744366a4ef661e399f24636ebe440d315ab35d768676c59c613186", size = 1244834, upload-time = "2025-08-26T15:12:14.795Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/5f/93b3e3607ccd693a768eafee60829cd14ea1810b75aa48e8b20e27b332c4/marisa_trie-1.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:99a00cab4cf9643a87977c87a5c8961aa44fff8d5dd46e00250135f686e7dedf", size = 1265148, upload-time = "2025-08-26T15:12:16.229Z" },
-    { url = "https://files.pythonhosted.org/packages/db/6e/051d7d25c7fb2b3df605c8bd782513ebbb33fddf3bae6cf46cf268cca89f/marisa_trie-1.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:83efc045fc58ca04c91a96c9b894d8a19ac6553677a76f96df01ff9f0405f53d", size = 2172726, upload-time = "2025-08-26T15:12:18.467Z" },
-    { url = "https://files.pythonhosted.org/packages/58/da/244d9d4e414ce6c73124cba4cc293dd140bf3b04ca18dec64c2775cca951/marisa_trie-1.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0b9816ab993001a7854b02a7daec228892f35bd5ab0ac493bacbd1b80baec9f1", size = 2256104, upload-time = "2025-08-26T15:12:20.168Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/f1/1a36ecd7da6668685a7753522af89a19928ffc80f1cc1dbc301af216f011/marisa_trie-1.3.1-cp312-cp312-win32.whl", hash = "sha256:c785fd6dae9daa6825734b7b494cdac972f958be1f9cb3fb1f32be8598d2b936", size = 115624, upload-time = "2025-08-26T15:12:21.233Z" },
-    { url = "https://files.pythonhosted.org/packages/35/b2/aabd1c9f1c102aa31d66633ed5328c447be166e0a703f9723e682478fd83/marisa_trie-1.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:9868b7a8e0f648d09ffe25ac29511e6e208cc5fb0d156c295385f9d5dc2a138e", size = 138562, upload-time = "2025-08-26T15:12:22.632Z" },
-    { url = "https://files.pythonhosted.org/packages/46/a2/8331b995c1b3eee83aa745f4a6502d737ec523d5955a48f167d4177db105/marisa_trie-1.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9de573d933db4753a50af891bcb3ffbfe14e200406214c223aa5dfe2163f316d", size = 172272, upload-time = "2025-08-26T15:12:24.016Z" },
-    { url = "https://files.pythonhosted.org/packages/97/b8/7b9681b5c0ea1bb950f907a4e3919eb7f7b7b3febafaae346f3b3f199f6f/marisa_trie-1.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4bae4f920f2a1082eaf766c1883df7da84abdf333bafa15b8717c10416a615e", size = 154671, upload-time = "2025-08-26T15:12:25.013Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/16/929c1f83fdcff13f8d08500f434aaa18c21c8168d16cf81585d69085e980/marisa_trie-1.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf9f2b97fcfd5e2dbb0090d0664023872dcde990df0b545eca8d0ce95795a409", size = 1238754, upload-time = "2025-08-26T15:12:26.217Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/0a/b0e04d3ef91a87d4c7ea0b66c004fdfc6e65c9ed83edaebecfb482dfe0ed/marisa_trie-1.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecdb19d33b26738a32602ef432b06cc6deeca4b498ce67ba8e5e39c8a7c19745", size = 1262653, upload-time = "2025-08-26T15:12:27.422Z" },
-    { url = "https://files.pythonhosted.org/packages/de/1f/0ecf610ddc9a209ee63116baabb47584d5b8ecd01610091a593d9429537e/marisa_trie-1.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a7416f1a084eb889c5792c57317875aeaa86abfe0bdc6f167712cebcec1d36ee", size = 2172399, upload-time = "2025-08-26T15:12:28.926Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/74/6b47deff3b3920449c135b9187c80f0d656adcdc5d41463745a61b012ea1/marisa_trie-1.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee428575377e29c636f2b4b3b0488875dcea310c6c5b3412ec4ef997f7bb37cc", size = 2255138, upload-time = "2025-08-26T15:12:30.271Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/fa/3dbcbe93dfaa626a5b3e741e7bcf3d7389aa5777175213bd8d9a9d3c992d/marisa_trie-1.3.1-cp313-cp313-win32.whl", hash = "sha256:d0f87bdf660f01e88ab3a507955697b2e3284065afa0b94fc9e77d6ad153ed5e", size = 115391, upload-time = "2025-08-26T15:12:31.465Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/ce/ddfab303646b21aef07ff9dbc83fba92e5d493f49d3bc03d899ffd45c86f/marisa_trie-1.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:a83f5f7ae3494e0cc25211296252b1b86901c788ed82c83adda19d0c98f828d6", size = 139130, upload-time = "2025-08-26T15:12:32.4Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/1e/734b618048ad05c50cb1673ce2c6e836dc38ddeeeb011ed1804af07327a4/marisa_trie-1.3.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:a850b151bd1e3a5d9afef113adc22727d696603659d575d7e84f994bd8d04bf1", size = 175131, upload-time = "2025-08-26T15:12:33.728Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/78/c7051147cc918cb8ff4a2920e11a9b17d9dcb4d8fc122122694b486e2bfe/marisa_trie-1.3.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9dc61fb8f8993589544f6df268229c6cf0a56ad4ed3e8585a9cd23c5ad79527b", size = 163094, upload-time = "2025-08-26T15:12:35.312Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/b8/3b904178d7878319aacaabae5131c1f281519aaac0f8c68c8ed312912ccf/marisa_trie-1.3.1-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4bd41a6e73c0d0adafe4de449b6d35530a4ce6a836a6ee839baf117785ecfd7", size = 1279812, upload-time = "2025-08-26T15:12:36.831Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/bf/e77a1284247b980560b4104bbdd5d06ed2c2ae3d56ab954f97293b6dbbcd/marisa_trie-1.3.1-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8c8b2386d2d22c57880ed20a913ceca86363765623175671137484a7d223f07a", size = 1285690, upload-time = "2025-08-26T15:12:38.754Z" },
-    { url = "https://files.pythonhosted.org/packages/48/82/f6f10db5ec72de2642499f3a6e4e8607bbd2cfb28269ea08d0d8ddac3313/marisa_trie-1.3.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9c56001badaf1779afae5c24b7ab85938644ab8ef3c5fd438ab5d49621b84482", size = 2197943, upload-time = "2025-08-26T15:12:40.584Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/d0/74b6c3011b1ebf4a8131430156b14c3af694082cf34c392fff766096fd4b/marisa_trie-1.3.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:83a3748088d117a9b15d8981c947df9e4f56eb2e4b5456ae34fe1f83666c9185", size = 2280132, upload-time = "2025-08-26T15:12:42.059Z" },
-    { url = "https://files.pythonhosted.org/packages/28/b2/b8b0cb738fa3ab07309ed92025c6e1b278f84c7255e976921a52b30d8d1b/marisa_trie-1.3.1-cp313-cp313t-win32.whl", hash = "sha256:137010598d8cebc53dbfb7caf59bde96c33a6af555e3e1bdbf30269b6a157e1e", size = 126446, upload-time = "2025-08-26T15:12:43.339Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/c6/2381648d0c946556ef51c673397cea40712d945444ceed0a0a0b51a174d2/marisa_trie-1.3.1-cp313-cp313t-win_amd64.whl", hash = "sha256:ec633e108f277f2b7f4671d933a909f39bba549910bf103e2940b87a14da2783", size = 153885, upload-time = "2025-08-26T15:12:44.309Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/87/1cb41b7bed959804e5b43cd071e14ea4199cd486f20a37e282d8eb4b8324/marisa_trie-1.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9a7c27b7ea89a49003da477fc07e6ca8ab8da79cd005c177bf9b92daad0244de", size = 206711, upload-time = "2026-03-10T15:26:28.064Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d5/36468e1696adae313fc2da07e3983dc131640e1739ccef08589e4c2efce7/marisa_trie-1.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:45e31d2d4c7fa9492a3828c9620544edf714f11a86cfede85fff61c5de2a5ec1", size = 190969, upload-time = "2026-03-10T15:26:29.522Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a2/1e0f0665a98968b0af7067cf2dad569e1bd8c1f13a97670b74b5ac5153d9/marisa_trie-1.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fc11658ff7eb5888e7a2bd5c9a98f73a2e03dbf252f844032d7181627e59017b", size = 1471808, upload-time = "2026-03-10T15:26:31.591Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c2/3842d8e39006b5b03384418b55108a3f3931ac6fe9b998814be81267acec/marisa_trie-1.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:20bc1a6936ba13b6b69684df2e41592f39f700f478e62453bb07fcfbefe1aa30", size = 1516387, upload-time = "2026-03-10T15:26:33.395Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/5a/08bc04f82e2a0196135529698ce6c38b9a6029cf7fce7b8aed8d8682dc0e/marisa_trie-1.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:50f20203e1738928556a1c7193cdf7863787f5739d7af34aa5c10a7e64fa4062", size = 2394299, upload-time = "2026-03-10T15:26:35.684Z" },
+    { url = "https://files.pythonhosted.org/packages/24/dc/b2a4cfad6065f6d207030949fede6cec00fcaf39740a5b433644102c24b0/marisa_trie-1.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:237713bb512122a28165c2a3eef227f98bffb0ce0c4baecf507a47e96a84f3d2", size = 2510947, upload-time = "2026-03-10T15:26:37.503Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/bd/f911ca551e93a6fbd8b13aff886b14ea635b683b30794f9bf7a9bf5c464d/marisa_trie-1.4.0-cp312-cp312-win32.whl", hash = "sha256:13cd029f783ded1a1387ecdedbb893d2419cf074ff84ca26698ca9115a12471c", size = 138864, upload-time = "2026-03-10T15:26:38.986Z" },
+    { url = "https://files.pythonhosted.org/packages/47/77/36995e4db2b0439ec228ad077a617e95a9d399c866223bffcaabe83336a5/marisa_trie-1.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:bae747cf7b8d3431c0769e385a326bc94a30ecc7df05f5c66cd8e26bdfb38bfb", size = 168498, upload-time = "2026-03-10T15:26:40.635Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c6/5dc0629abc08767d33b77dc45813a4ba9a84f6a5827326fb5a4f148a81a2/marisa_trie-1.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b115df26be8baabdedb755e422aa7c4a0bfb03b08711bc99c71d0288e9e8f43f", size = 206614, upload-time = "2026-03-10T15:26:42.284Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/64/964fef9f214ed605ba1f7d5f4f5bdc268259a7791063a955248a2b2a291f/marisa_trie-1.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:04e25e6b5b96d16711b94f77b5903368034c9dff93217e246e7d35ddf1f3b922", size = 190095, upload-time = "2026-03-10T15:26:43.321Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8e/783cbd69bf9eeddc68f2489d9f290cc8bc69e6b540a46aca2850a6af4b64/marisa_trie-1.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c143fe4cb246de22d22afc6ee71a1d706255ebd05db0e245ade6d3c61a96d3ad", size = 1474514, upload-time = "2026-03-10T15:26:44.644Z" },
+    { url = "https://files.pythonhosted.org/packages/50/8b/4d579938d55150ee3f67ad51db9fcd3f52c6c149afd20c9acd58d0f33e53/marisa_trie-1.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:33cca20e60a78da01650d67ef97d60f3ec8a2b60d4dea2d65306fb418d17039d", size = 1501007, upload-time = "2026-03-10T15:26:46.002Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/f8/25e15c3b9909208a9efcb2e16dfdb6b1fd5960571124bf140c1490d0984b/marisa_trie-1.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:73e61bee76e9e329a45a95b5fa5d50ecd06d9186d628b5e5a6b15c8de73b0789", size = 2397187, upload-time = "2026-03-10T15:26:47.438Z" },
+    { url = "https://files.pythonhosted.org/packages/96/55/f78d4b6ce1a51e0daff4e1ba2ec6250d88a1600e9667f9c2d1dfb967c554/marisa_trie-1.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0516c3aa096e687cf4cd073be5d4c82a82a3e1e1912fb3140f67c556ac6df814", size = 2498721, upload-time = "2026-03-10T15:26:48.755Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/59/86ad4efd87ad053001d07ae7a1a6d35c797d04966bfe2484f4a73388e469/marisa_trie-1.4.0-cp313-cp313-win32.whl", hash = "sha256:b9056b823aa4f5d4fcd6535b2dee946c3dc9b208453ab46f1f86ab73845be287", size = 138691, upload-time = "2026-03-10T15:26:50.661Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ad/8562d030685071e62c1502619e58d2c44d2729f18fb5f1d5c1514c247f07/marisa_trie-1.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:d89a8f5e805c4c416591724890cd6dd1f851a9019ac79c2cb3be565b3612d3ce", size = 168881, upload-time = "2026-03-10T15:26:51.939Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/34/b98a323653348fd67e108ae74a4360af2405cbc83a93bc4a5a46e9457b05/marisa_trie-1.4.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:7b438b9fe4d599bb4c199aa973c91221579d167655df2f90f4da8fe3e67e6757", size = 213362, upload-time = "2026-03-10T15:26:53.29Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/a9/9b11fb7cc512ddcd8dcd4217e52e70fd7cf8af290c6c6a7163f9e4c9dc4b/marisa_trie-1.4.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:df838cb2e41823cf0aed75282b8d071acf40f5513e22713e98bebf9970a080dc", size = 202021, upload-time = "2026-03-10T15:26:54.48Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ca/6ca2a7dc013bfa782f16137328b6f33ed7c2926e25f02d7f0bdb3864ca81/marisa_trie-1.4.0-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02f087ff7d9a48ff03f7b05469e2311fcdfc324c70e7e06789c311d7986de56b", size = 1542390, upload-time = "2026-03-10T15:26:55.771Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/0f/8957f0f4cf0024c2d1d33745f81822de9c71409b2e1f08ebde88c6b6f133/marisa_trie-1.4.0-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e5d945b832b9f61db5840ba01f7f54022780fb2826fd134672e63bcac3e56a0d", size = 1545485, upload-time = "2026-03-10T15:26:58.087Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4a/67ac5fa636e8ff7372e773d979d49427bcecaa2e4a2beb2f7f69517d0daa/marisa_trie-1.4.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9866f6dcff7e5ba714b1ca21aba6da881efab5b2bec656de5dc67d05cab300b6", size = 2447005, upload-time = "2026-03-10T15:26:59.871Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/59/c6d93f123ba5578c3e5f57dd116622d35dc912a38b725ed4cbeebac5b4bc/marisa_trie-1.4.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c5352f1a2b7faa194df97fb2071f6ac5de0f13ead4162beba6f45a1d81d20fe3", size = 2535998, upload-time = "2026-03-10T15:27:01.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/3b/ac6a8ab64eeecca770b61ceb39ef21eaf4ade810182bb10efa5127015a79/marisa_trie-1.4.0-cp313-cp313t-win32.whl", hash = "sha256:e8f23a504d1cd5c310f69fbb4638dd5b5a1626b4ebc523fb741716be8c02d4db", size = 153910, upload-time = "2026-03-10T15:27:02.416Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/4c/c4bf8eee002ef58bb503e6bde0ab1c9720ac16e67587216bd26716099718/marisa_trie-1.4.0-cp313-cp313t-win_amd64.whl", hash = "sha256:c55830565f53abe7fff9e4a3cea9c4bf828e19da0549b082addff704e2a1b2b3", size = 186644, upload-time = "2026-03-10T15:27:03.895Z" },
 ]
 
 [[package]]
@@ -1568,168 +1600,42 @@ wheels = [
 
 [[package]]
 name = "numpy"
-version = "2.4.2"
+version = "2.4.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/57/fd/0005efbd0af48e55eb3c7208af93f2862d4b1a56cd78e84309a2d959208d/numpy-2.4.2.tar.gz", hash = "sha256:659a6107e31a83c4e33f763942275fd278b21d095094044eb35569e86a21ddae", size = 20723651, upload-time = "2026-01-31T23:13:10.135Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/8b/c265f4823726ab832de836cdd184d0986dcf94480f81e8739692a7ac7af2/numpy-2.4.3.tar.gz", hash = "sha256:483a201202b73495f00dbc83796c6ae63137a9bdade074f7648b3e32613412dd", size = 20727743, upload-time = "2026-03-09T07:58:53.426Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/6e/6f394c9c77668153e14d4da83bcc247beb5952f6ead7699a1a2992613bea/numpy-2.4.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:21982668592194c609de53ba4933a7471880ccbaadcc52352694a59ecc860b3a", size = 16667963, upload-time = "2026-01-31T23:10:52.147Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/f8/55483431f2b2fd015ae6ed4fe62288823ce908437ed49db5a03d15151678/numpy-2.4.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40397bda92382fcec844066efb11f13e1c9a3e2a8e8f318fb72ed8b6db9f60f1", size = 14693571, upload-time = "2026-01-31T23:10:54.789Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/20/18026832b1845cdc82248208dd929ca14c9d8f2bac391f67440707fff27c/numpy-2.4.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:b3a24467af63c67829bfaa61eecf18d5432d4f11992688537be59ecd6ad32f5e", size = 5203469, upload-time = "2026-01-31T23:10:57.343Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/33/2eb97c8a77daaba34eaa3fa7241a14ac5f51c46a6bd5911361b644c4a1e2/numpy-2.4.2-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:805cc8de9fd6e7a22da5aed858e0ab16be5a4db6c873dde1d7451c541553aa27", size = 6550820, upload-time = "2026-01-31T23:10:59.429Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/91/b97fdfd12dc75b02c44e26c6638241cc004d4079a0321a69c62f51470c4c/numpy-2.4.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d82351358ffbcdcd7b686b90742a9b86632d6c1c051016484fa0b326a0a1548", size = 15663067, upload-time = "2026-01-31T23:11:01.291Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/c6/a18e59f3f0b8071cc85cbc8d80cd02d68aa9710170b2553a117203d46936/numpy-2.4.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9e35d3e0144137d9fdae62912e869136164534d64a169f86438bc9561b6ad49f", size = 16619782, upload-time = "2026-01-31T23:11:03.669Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/83/9751502164601a79e18847309f5ceec0b1446d7b6aa12305759b72cf98b2/numpy-2.4.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adb6ed2ad29b9e15321d167d152ee909ec73395901b70936f029c3bc6d7f4460", size = 17013128, upload-time = "2026-01-31T23:11:05.913Z" },
-    { url = "https://files.pythonhosted.org/packages/61/c4/c4066322256ec740acc1c8923a10047818691d2f8aec254798f3dd90f5f2/numpy-2.4.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8906e71fd8afcb76580404e2a950caef2685df3d2a57fe82a86ac8d33cc007ba", size = 18345324, upload-time = "2026-01-31T23:11:08.248Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/af/6157aa6da728fa4525a755bfad486ae7e3f76d4c1864138003eb84328497/numpy-2.4.2-cp312-cp312-win32.whl", hash = "sha256:ec055f6dae239a6299cace477b479cca2fc125c5675482daf1dd886933a1076f", size = 5960282, upload-time = "2026-01-31T23:11:10.497Z" },
-    { url = "https://files.pythonhosted.org/packages/92/0f/7ceaaeaacb40567071e94dbf2c9480c0ae453d5bb4f52bea3892c39dc83c/numpy-2.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:209fae046e62d0ce6435fcfe3b1a10537e858249b3d9b05829e2a05218296a85", size = 12314210, upload-time = "2026-01-31T23:11:12.176Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/a3/56c5c604fae6dd40fa2ed3040d005fca97e91bd320d232ac9931d77ba13c/numpy-2.4.2-cp312-cp312-win_arm64.whl", hash = "sha256:fbde1b0c6e81d56f5dccd95dd4a711d9b95df1ae4009a60887e56b27e8d903fa", size = 10220171, upload-time = "2026-01-31T23:11:14.684Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/22/815b9fe25d1d7ae7d492152adbc7226d3eff731dffc38fe970589fcaaa38/numpy-2.4.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:25f2059807faea4b077a2b6837391b5d830864b3543627f381821c646f31a63c", size = 16663696, upload-time = "2026-01-31T23:11:17.516Z" },
-    { url = "https://files.pythonhosted.org/packages/09/f0/817d03a03f93ba9c6c8993de509277d84e69f9453601915e4a69554102a1/numpy-2.4.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bd3a7a9f5847d2fb8c2c6d1c862fa109c31a9abeca1a3c2bd5a64572955b2979", size = 14688322, upload-time = "2026-01-31T23:11:19.883Z" },
-    { url = "https://files.pythonhosted.org/packages/da/b4/f805ab79293c728b9a99438775ce51885fd4f31b76178767cfc718701a39/numpy-2.4.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:8e4549f8a3c6d13d55041925e912bfd834285ef1dd64d6bc7d542583355e2e98", size = 5198157, upload-time = "2026-01-31T23:11:22.375Z" },
-    { url = "https://files.pythonhosted.org/packages/74/09/826e4289844eccdcd64aac27d13b0fd3f32039915dd5b9ba01baae1f436c/numpy-2.4.2-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:aea4f66ff44dfddf8c2cffd66ba6538c5ec67d389285292fe428cb2c738c8aef", size = 6546330, upload-time = "2026-01-31T23:11:23.958Z" },
-    { url = "https://files.pythonhosted.org/packages/19/fb/cbfdbfa3057a10aea5422c558ac57538e6acc87ec1669e666d32ac198da7/numpy-2.4.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3cd545784805de05aafe1dde61752ea49a359ccba9760c1e5d1c88a93bbf2b7", size = 15660968, upload-time = "2026-01-31T23:11:25.713Z" },
-    { url = "https://files.pythonhosted.org/packages/04/dc/46066ce18d01645541f0186877377b9371b8fa8017fa8262002b4ef22612/numpy-2.4.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d0d9b7c93578baafcbc5f0b83eaf17b79d345c6f36917ba0c67f45226911d499", size = 16607311, upload-time = "2026-01-31T23:11:28.117Z" },
-    { url = "https://files.pythonhosted.org/packages/14/d9/4b5adfc39a43fa6bf918c6d544bc60c05236cc2f6339847fc5b35e6cb5b0/numpy-2.4.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f74f0f7779cc7ae07d1810aab8ac6b1464c3eafb9e283a40da7309d5e6e48fbb", size = 17012850, upload-time = "2026-01-31T23:11:30.888Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/20/adb6e6adde6d0130046e6fdfb7675cc62bc2f6b7b02239a09eb58435753d/numpy-2.4.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c7ac672d699bf36275c035e16b65539931347d68b70667d28984c9fb34e07fa7", size = 18334210, upload-time = "2026-01-31T23:11:33.214Z" },
-    { url = "https://files.pythonhosted.org/packages/78/0e/0a73b3dff26803a8c02baa76398015ea2a5434d9b8265a7898a6028c1591/numpy-2.4.2-cp313-cp313-win32.whl", hash = "sha256:8e9afaeb0beff068b4d9cd20d322ba0ee1cecfb0b08db145e4ab4dd44a6b5110", size = 5958199, upload-time = "2026-01-31T23:11:35.385Z" },
-    { url = "https://files.pythonhosted.org/packages/43/bc/6352f343522fcb2c04dbaf94cb30cca6fd32c1a750c06ad6231b4293708c/numpy-2.4.2-cp313-cp313-win_amd64.whl", hash = "sha256:7df2de1e4fba69a51c06c28f5a3de36731eb9639feb8e1cf7e4a7b0daf4cf622", size = 12310848, upload-time = "2026-01-31T23:11:38.001Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/8d/6da186483e308da5da1cc6918ce913dcfe14ffde98e710bfeff2a6158d4e/numpy-2.4.2-cp313-cp313-win_arm64.whl", hash = "sha256:0fece1d1f0a89c16b03442eae5c56dc0be0c7883b5d388e0c03f53019a4bfd71", size = 10221082, upload-time = "2026-01-31T23:11:40.392Z" },
-    { url = "https://files.pythonhosted.org/packages/25/a1/9510aa43555b44781968935c7548a8926274f815de42ad3997e9e83680dd/numpy-2.4.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5633c0da313330fd20c484c78cdd3f9b175b55e1a766c4a174230c6b70ad8262", size = 14815866, upload-time = "2026-01-31T23:11:42.495Z" },
-    { url = "https://files.pythonhosted.org/packages/36/30/6bbb5e76631a5ae46e7923dd16ca9d3f1c93cfa8d4ed79a129814a9d8db3/numpy-2.4.2-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:d9f64d786b3b1dd742c946c42d15b07497ed14af1a1f3ce840cce27daa0ce913", size = 5325631, upload-time = "2026-01-31T23:11:44.7Z" },
-    { url = "https://files.pythonhosted.org/packages/46/00/3a490938800c1923b567b3a15cd17896e68052e2145d8662aaf3e1ffc58f/numpy-2.4.2-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:b21041e8cb6a1eb5312dd1d2f80a94d91efffb7a06b70597d44f1bd2dfc315ab", size = 6646254, upload-time = "2026-01-31T23:11:46.341Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/e9/fac0890149898a9b609caa5af7455a948b544746e4b8fe7c212c8edd71f8/numpy-2.4.2-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:00ab83c56211a1d7c07c25e3217ea6695e50a3e2f255053686b081dc0b091a82", size = 15720138, upload-time = "2026-01-31T23:11:48.082Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/5c/08887c54e68e1e28df53709f1893ce92932cc6f01f7c3d4dc952f61ffd4e/numpy-2.4.2-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fb882da679409066b4603579619341c6d6898fc83a8995199d5249f986e8e8f", size = 16655398, upload-time = "2026-01-31T23:11:50.293Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/89/253db0fa0e66e9129c745e4ef25631dc37d5f1314dad2b53e907b8538e6d/numpy-2.4.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:66cb9422236317f9d44b67b4d18f44efe6e9c7f8794ac0462978513359461554", size = 17079064, upload-time = "2026-01-31T23:11:52.927Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/d5/cbade46ce97c59c6c3da525e8d95b7abe8a42974a1dc5c1d489c10433e88/numpy-2.4.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0f01dcf33e73d80bd8dc0f20a71303abbafa26a19e23f6b68d1aa9990af90257", size = 18379680, upload-time = "2026-01-31T23:11:55.22Z" },
-    { url = "https://files.pythonhosted.org/packages/40/62/48f99ae172a4b63d981babe683685030e8a3df4f246c893ea5c6ef99f018/numpy-2.4.2-cp313-cp313t-win32.whl", hash = "sha256:52b913ec40ff7ae845687b0b34d8d93b60cb66dcee06996dd5c99f2fc9328657", size = 6082433, upload-time = "2026-01-31T23:11:58.096Z" },
-    { url = "https://files.pythonhosted.org/packages/07/38/e054a61cfe48ad9f1ed0d188e78b7e26859d0b60ef21cd9de4897cdb5326/numpy-2.4.2-cp313-cp313t-win_amd64.whl", hash = "sha256:5eea80d908b2c1f91486eb95b3fb6fab187e569ec9752ab7d9333d2e66bf2d6b", size = 12451181, upload-time = "2026-01-31T23:11:59.782Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/a4/a05c3a6418575e185dd84d0b9680b6bb2e2dc3e4202f036b7b4e22d6e9dc/numpy-2.4.2-cp313-cp313t-win_arm64.whl", hash = "sha256:fd49860271d52127d61197bb50b64f58454e9f578cb4b2c001a6de8b1f50b0b1", size = 10290756, upload-time = "2026-01-31T23:12:02.438Z" },
-]
-
-[[package]]
-name = "nvidia-cublas-cu12"
-version = "12.8.4.1"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921, upload-time = "2025-03-07T01:44:31.254Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-cupti-cu12"
-version = "12.8.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-nvrtc-cu12"
-version = "12.8.93"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029, upload-time = "2025-03-07T01:42:13.562Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-runtime-cu12"
-version = "12.8.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
-]
-
-[[package]]
-name = "nvidia-cudnn-cu12"
-version = "9.10.2.21"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-cublas-cu12" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
-]
-
-[[package]]
-name = "nvidia-cufft-cu12"
-version = "11.3.3.83"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
-]
-
-[[package]]
-name = "nvidia-cufile-cu12"
-version = "1.13.1.3"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834, upload-time = "2025-03-07T01:45:50.723Z" },
-]
-
-[[package]]
-name = "nvidia-curand-cu12"
-version = "10.3.9.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976, upload-time = "2025-03-07T01:46:23.323Z" },
-]
-
-[[package]]
-name = "nvidia-cusolver-cu12"
-version = "11.7.3.90"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
-]
-
-[[package]]
-name = "nvidia-cusparse-cu12"
-version = "12.5.8.93"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
-]
-
-[[package]]
-name = "nvidia-cusparselt-cu12"
-version = "0.7.1"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691, upload-time = "2025-02-26T00:15:44.104Z" },
-]
-
-[[package]]
-name = "nvidia-nccl-cu12"
-version = "2.27.3"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/5b/4e4fff7bad39adf89f735f2bc87248c81db71205b62bcc0d5ca5b606b3c3/nvidia_nccl_cu12-2.27.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adf27ccf4238253e0b826bce3ff5fa532d65fc42322c8bfdfaf28024c0fbe039", size = 322364134, upload-time = "2025-06-03T21:58:04.013Z" },
-]
-
-[[package]]
-name = "nvidia-nvjitlink-cu12"
-version = "12.8.93"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836, upload-time = "2025-03-07T01:49:55.661Z" },
-]
-
-[[package]]
-name = "nvidia-nvtx-cu12"
-version = "12.8.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ed/6388632536f9788cea23a3a1b629f25b43eaacd7d7377e5d6bc7b9deb69b/numpy-2.4.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:61b0cbabbb6126c8df63b9a3a0c4b1f44ebca5e12ff6997b80fcf267fb3150ef", size = 16669628, upload-time = "2026-03-09T07:56:24.252Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1b/ee2abfc68e1ce728b2958b6ba831d65c62e1b13ce3017c13943f8f9b5b2e/numpy-2.4.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7395e69ff32526710748f92cd8c9849b361830968ea3e24a676f272653e8983e", size = 14696872, upload-time = "2026-03-09T07:56:26.991Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/d1/780400e915ff5638166f11ca9dc2c5815189f3d7cf6f8759a1685e586413/numpy-2.4.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:abdce0f71dcb4a00e4e77f3faf05e4616ceccfe72ccaa07f47ee79cda3b7b0f4", size = 5203489, upload-time = "2026-03-09T07:56:29.414Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/bb/baffa907e9da4cc34a6e556d6d90e032f6d7a75ea47968ea92b4858826c4/numpy-2.4.3-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:48da3a4ee1336454b07497ff7ec83903efa5505792c4e6d9bf83d99dc07a1e18", size = 6550814, upload-time = "2026-03-09T07:56:32.225Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/12/8c9f0c6c95f76aeb20fc4a699c33e9f827fa0d0f857747c73bb7b17af945/numpy-2.4.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:32e3bef222ad6b052280311d1d60db8e259e4947052c3ae7dd6817451fc8a4c5", size = 15666601, upload-time = "2026-03-09T07:56:34.461Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/79/cc665495e4d57d0aa6fbcc0aa57aa82671dfc78fbf95fe733ed86d98f52a/numpy-2.4.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e7dd01a46700b1967487141a66ac1a3cf0dd8ebf1f08db37d46389401512ca97", size = 16621358, upload-time = "2026-03-09T07:56:36.852Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/40/b4ecb7224af1065c3539f5ecfff879d090de09608ad1008f02c05c770cb3/numpy-2.4.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:76f0f283506c28b12bba319c0fab98217e9f9b54e6160e9c79e9f7348ba32e9c", size = 17016135, upload-time = "2026-03-09T07:56:39.337Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/b1/6a88e888052eed951afed7a142dcdf3b149a030ca59b4c71eef085858e43/numpy-2.4.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:737f630a337364665aba3b5a77e56a68cc42d350edd010c345d65a3efa3addcc", size = 18345816, upload-time = "2026-03-09T07:56:42.31Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/8f/103a60c5f8c3d7fc678c19cd7b2476110da689ccb80bc18050efbaeae183/numpy-2.4.3-cp312-cp312-win32.whl", hash = "sha256:26952e18d82a1dbbc2f008d402021baa8d6fc8e84347a2072a25e08b46d698b9", size = 5960132, upload-time = "2026-03-09T07:56:44.851Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/7c/f5ee1bf6ed888494978046a809df2882aad35d414b622893322df7286879/numpy-2.4.3-cp312-cp312-win_amd64.whl", hash = "sha256:65f3c2455188f09678355f5cae1f959a06b778bc66d535da07bf2ef20cd319d5", size = 12316144, upload-time = "2026-03-09T07:56:47.057Z" },
+    { url = "https://files.pythonhosted.org/packages/71/46/8d1cb3f7a00f2fb6394140e7e6623696e54c6318a9d9691bb4904672cf42/numpy-2.4.3-cp312-cp312-win_arm64.whl", hash = "sha256:2abad5c7fef172b3377502bde47892439bae394a71bc329f31df0fd829b41a9e", size = 10220364, upload-time = "2026-03-09T07:56:49.849Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/d0/1fe47a98ce0df229238b77611340aff92d52691bcbc10583303181abf7fc/numpy-2.4.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b346845443716c8e542d54112966383b448f4a3ba5c66409771b8c0889485dd3", size = 16665297, upload-time = "2026-03-09T07:56:52.296Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d9/4e7c3f0e68dfa91f21c6fb6cf839bc829ec920688b1ce7ec722b1a6202fb/numpy-2.4.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2629289168f4897a3c4e23dc98d6f1731f0fc0fe52fb9db19f974041e4cc12b9", size = 14691853, upload-time = "2026-03-09T07:56:54.992Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/66/bd096b13a87549683812b53ab211e6d413497f84e794fb3c39191948da97/numpy-2.4.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:bb2e3cf95854233799013779216c57e153c1ee67a0bf92138acca0e429aefaee", size = 5198435, upload-time = "2026-03-09T07:56:57.184Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/2f/687722910b5a5601de2135c891108f51dfc873d8e43c8ed9f4ebb440b4a2/numpy-2.4.3-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:7f3408ff897f8ab07a07fbe2823d7aee6ff644c097cc1f90382511fe982f647f", size = 6546347, upload-time = "2026-03-09T07:56:59.531Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ec/7971c4e98d86c564750393fab8d7d83d0a9432a9d78bb8a163a6dc59967a/numpy-2.4.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:decb0eb8a53c3b009b0962378065589685d66b23467ef5dac16cbe818afde27f", size = 15664626, upload-time = "2026-03-09T07:57:01.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/eb/7daecbea84ec935b7fc732e18f532073064a3816f0932a40a17f3349185f/numpy-2.4.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5f51900414fc9204a0e0da158ba2ac52b75656e7dce7e77fb9f84bfa343b4cc", size = 16608916, upload-time = "2026-03-09T07:57:04.008Z" },
+    { url = "https://files.pythonhosted.org/packages/df/58/2a2b4a817ffd7472dca4421d9f0776898b364154e30c95f42195041dc03b/numpy-2.4.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6bd06731541f89cdc01b261ba2c9e037f1543df7472517836b78dfb15bd6e476", size = 17015824, upload-time = "2026-03-09T07:57:06.347Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ca/627a828d44e78a418c55f82dd4caea8ea4a8ef24e5144d9e71016e52fb40/numpy-2.4.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22654fe6be0e5206f553a9250762c653d3698e46686eee53b399ab90da59bd92", size = 18334581, upload-time = "2026-03-09T07:57:09.114Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c0/76f93962fc79955fcba30a429b62304332345f22d4daec1cb33653425643/numpy-2.4.3-cp313-cp313-win32.whl", hash = "sha256:d71e379452a2f670ccb689ec801b1218cd3983e253105d6e83780967e899d687", size = 5958618, upload-time = "2026-03-09T07:57:11.432Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3c/88af0040119209b9b5cb59485fa48b76f372c73068dbf9254784b975ac53/numpy-2.4.3-cp313-cp313-win_amd64.whl", hash = "sha256:0a60e17a14d640f49146cb38e3f105f571318db7826d9b6fef7e4dce758faecd", size = 12312824, upload-time = "2026-03-09T07:57:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ce/3d07743aced3d173f877c3ef6a454c2174ba42b584ab0b7e6d99374f51ed/numpy-2.4.3-cp313-cp313-win_arm64.whl", hash = "sha256:c9619741e9da2059cd9c3f206110b97583c7152c1dc9f8aafd4beb450ac1c89d", size = 10221218, upload-time = "2026-03-09T07:57:16.183Z" },
+    { url = "https://files.pythonhosted.org/packages/62/09/d96b02a91d09e9d97862f4fc8bfebf5400f567d8eb1fe4b0cc4795679c15/numpy-2.4.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:7aa4e54f6469300ebca1d9eb80acd5253cdfa36f2c03d79a35883687da430875", size = 14819570, upload-time = "2026-03-09T07:57:18.564Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/ca/0b1aba3905fdfa3373d523b2b15b19029f4f3031c87f4066bd9d20ef6c6b/numpy-2.4.3-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:d1b90d840b25874cf5cd20c219af10bac3667db3876d9a495609273ebe679070", size = 5326113, upload-time = "2026-03-09T07:57:21.052Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/63/406e0fd32fcaeb94180fd6a4c41e55736d676c54346b7efbce548b94a914/numpy-2.4.3-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:a749547700de0a20a6718293396ec237bb38218049cfce788e08fcb716e8cf73", size = 6646370, upload-time = "2026-03-09T07:57:22.804Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/d0/10f7dc157d4b37af92720a196be6f54f889e90dcd30dce9dc657ed92c257/numpy-2.4.3-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94f3c4a151a2e529adf49c1d54f0f57ff8f9b233ee4d44af623a81553ab86368", size = 15723499, upload-time = "2026-03-09T07:57:24.693Z" },
+    { url = "https://files.pythonhosted.org/packages/66/f1/d1c2bf1161396629701bc284d958dc1efa3a5a542aab83cf11ee6eb4cba5/numpy-2.4.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22c31dc07025123aedf7f2db9e91783df13f1776dc52c6b22c620870dc0fab22", size = 16657164, upload-time = "2026-03-09T07:57:27.676Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/cca19230b740af199ac47331a21c71e7a3d0ba59661350483c1600d28c37/numpy-2.4.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:148d59127ac95979d6f07e4d460f934ebdd6eed641db9c0db6c73026f2b2101a", size = 17081544, upload-time = "2026-03-09T07:57:30.664Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c5/9602b0cbb703a0936fb40f8a95407e8171935b15846de2f0776e08af04c7/numpy-2.4.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a97cbf7e905c435865c2d939af3d93f99d18eaaa3cabe4256f4304fb51604349", size = 18380290, upload-time = "2026-03-09T07:57:33.763Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/81/9f24708953cd30be9ee36ec4778f4b112b45165812f2ada4cc5ea1c1f254/numpy-2.4.3-cp313-cp313t-win32.whl", hash = "sha256:be3b8487d725a77acccc9924f65fd8bce9af7fac8c9820df1049424a2115af6c", size = 6082814, upload-time = "2026-03-09T07:57:36.491Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/9e/52f6eaa13e1a799f0ab79066c17f7016a4a8ae0c1aefa58c82b4dab690b4/numpy-2.4.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1ec84fd7c8e652b0f4aaaf2e6e9cc8eaa9b1b80a537e06b2e3a2fb176eedcb26", size = 12452673, upload-time = "2026-03-09T07:57:38.281Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/04/b8cece6ead0b30c9fbd99bb835ad7ea0112ac5f39f069788c5558e3b1ab2/numpy-2.4.3-cp313-cp313t-win_arm64.whl", hash = "sha256:120df8c0a81ebbf5b9020c91439fccd85f5e018a927a39f624845be194a2be02", size = 10290907, upload-time = "2026-03-09T07:57:40.747Z" },
 ]
 
 [[package]]
@@ -1747,7 +1653,7 @@ wheels = [
 
 [[package]]
 name = "onnxruntime"
-version = "1.24.2"
+version = "1.24.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flatbuffers" },
@@ -1757,61 +1663,61 @@ dependencies = [
     { name = "sympy" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/1c/38af1cfe82c75d2b205eb5019834b0f2b0b6647ec8a20a3086168e413570/onnxruntime-1.24.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:d8a50b422d45c0144864c0977d04ad4fa50a8a48e5153056ab1f7d06ea9fc3e2", size = 17217857, upload-time = "2026-02-19T17:15:14.297Z" },
-    { url = "https://files.pythonhosted.org/packages/01/8a/e2d4332ae18d6383376e75141cd914256bee12c3cc439f42260eb176ceb9/onnxruntime-1.24.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:76c44fc9a89dcefcd5a4ab5c6bbbb9ff1604325ab2d5d0bc9ff5a9cba7b37f4a", size = 15027167, upload-time = "2026-02-19T17:13:21.92Z" },
-    { url = "https://files.pythonhosted.org/packages/35/af/ad86cfbfd65d5a86204b3a30893e92c0cf3f1a56280efc5a12e69d81f52d/onnxruntime-1.24.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:09aa6f8d766b4afc3cfba68dd10be39586b49f9462fbd1386c5d5644239461ca", size = 17106547, upload-time = "2026-02-19T17:14:05.758Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/62/9d725326f933bf8323e309956a17e52d33fb59d35bb5dda1886f94352938/onnxruntime-1.24.2-cp312-cp312-win_amd64.whl", hash = "sha256:ebcee9276420a65e5fa08b05f18379c2271b5992617e5bdc0d0d6c5ea395c1a1", size = 12506161, upload-time = "2026-02-19T17:14:59.377Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/a9/7b06efd5802db881860d961a7cb4efacb058ed694c1c8f096c0c1499d017/onnxruntime-1.24.2-cp312-cp312-win_arm64.whl", hash = "sha256:8d770a934513f6e17937baf3438eaaec5983a23cdaedb81c9fc0dfcf26831c24", size = 12169884, upload-time = "2026-02-19T17:14:49.962Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/98/8f5b9ae63f7f6dd5fb2d192454b915ec966a421fdd0effeeef5be7f7221f/onnxruntime-1.24.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:038ebcd8363c3835ea83eed66129e1d11d8219438892dfb7dc7656c4d4dfa1f9", size = 17217884, upload-time = "2026-02-19T17:13:36.193Z" },
-    { url = "https://files.pythonhosted.org/packages/55/e6/dc4dc59565c93506c45017c0dd3f536f6d1b7bc97047821af13fba2e3def/onnxruntime-1.24.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8235cc11e118ad749c497ba93288c04073eccd8cc6cc508c8a7988ae36ab52d8", size = 15026995, upload-time = "2026-02-19T17:13:25.029Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/62/6f2851cf3237a91bc04cdb35434293a623d4f6369f79836929600da574ba/onnxruntime-1.24.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e92b46cc6d8be4286436a05382a881c88d85a2ae1ea9cfe5e6fab89f2c3e89cc", size = 17106308, upload-time = "2026-02-19T17:14:09.817Z" },
-    { url = "https://files.pythonhosted.org/packages/62/5a/1e2b874daf24f26e98af14281fdbdd6ae1ed548ba471c01ea2a3084c55bb/onnxruntime-1.24.2-cp313-cp313-win_amd64.whl", hash = "sha256:1fd824ee4f6fb811bc47ffec2b25f129f31a087214ca91c8b4f6fda32962b78f", size = 12506095, upload-time = "2026-02-19T17:15:02.434Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/6f/8fac5eecb94f861d56a43ede3c2ebcdce60132952d3b72003f3e3d91483c/onnxruntime-1.24.2-cp313-cp313-win_arm64.whl", hash = "sha256:d8cf0acbf90771fff012c33eb2749e8aca2a8b4c66c672f30ee77c140a6fba5b", size = 12168564, upload-time = "2026-02-19T17:14:52.28Z" },
-    { url = "https://files.pythonhosted.org/packages/35/e4/7dfed3f445f7289a0abff709d012439c6c901915390704dd918e5f47aad3/onnxruntime-1.24.2-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e22fb5d9ac51b61f50cca155ce2927576cc2c42501ede6c0df23a1aeb070bdd5", size = 15036844, upload-time = "2026-02-19T17:13:27.928Z" },
-    { url = "https://files.pythonhosted.org/packages/90/45/9d52397e30b0d8c1692afcec5184ca9372ff4d6b0f6039bba9ad479a2563/onnxruntime-1.24.2-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2956f5220e7be8b09482ae5726caabf78eb549142cdb28523191a38e57fb6119", size = 17117779, upload-time = "2026-02-19T17:14:13.862Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/7f/dfdc4e52600fde4c02d59bfe98c4b057931c1114b701e175aee311a9bc11/onnxruntime-1.24.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:0d244227dc5e00a9ae15a7ac1eba4c4460d7876dfecafe73fb00db9f1d914d91", size = 17342578, upload-time = "2026-03-05T17:19:02.403Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/dc/1f5489f7b21817d4ad352bf7a92a252bd5b438bcbaa7ad20ea50814edc79/onnxruntime-1.24.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a9847b870b6cb462652b547bc98c49e0efb67553410a082fde1918a38707452", size = 15150105, upload-time = "2026-03-05T16:34:56.897Z" },
+    { url = "https://files.pythonhosted.org/packages/28/7c/fd253da53594ab8efbefdc85b3638620ab1a6aab6eb7028a513c853559ce/onnxruntime-1.24.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b354afce3333f2859c7e8706d84b6c552beac39233bcd3141ce7ab77b4cabb5d", size = 17237101, upload-time = "2026-03-05T17:18:02.561Z" },
+    { url = "https://files.pythonhosted.org/packages/71/5f/eaabc5699eeed6a9188c5c055ac1948ae50138697a0428d562ac970d7db5/onnxruntime-1.24.3-cp312-cp312-win_amd64.whl", hash = "sha256:44ea708c34965439170d811267c51281d3897ecfc4aa0087fa25d4a4c3eb2e4a", size = 12597638, upload-time = "2026-03-05T17:18:52.141Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/5c/d8066c320b90610dbeb489a483b132c3b3879b2f93f949fb5d30cfa9b119/onnxruntime-1.24.3-cp312-cp312-win_arm64.whl", hash = "sha256:48d1092b44ca2ba6f9543892e7c422c15a568481403c10440945685faf27a8d8", size = 12270943, upload-time = "2026-03-05T17:18:42.006Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8d/487ece554119e2991242d4de55de7019ac6e47ee8dfafa69fcf41d37f8ed/onnxruntime-1.24.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:34a0ea5ff191d8420d9c1332355644148b1bf1a0d10c411af890a63a9f662aa7", size = 17342706, upload-time = "2026-03-05T16:35:10.813Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/25/8b444f463c1ac6106b889f6235c84f01eec001eaf689c3eff8c69cf48fae/onnxruntime-1.24.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fd2ec7bb0fabe42f55e8337cfc9b1969d0d14622711aac73d69b4bd5abb5ed7", size = 15149956, upload-time = "2026-03-05T16:34:59.264Z" },
+    { url = "https://files.pythonhosted.org/packages/34/fc/c9182a3e1ab46940dd4f30e61071f59eee8804c1f641f37ce6e173633fb6/onnxruntime-1.24.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df8e70e732fe26346faaeec9147fa38bef35d232d2495d27e93dd221a2d473a9", size = 17237370, upload-time = "2026-03-05T17:18:05.258Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7e/3b549e1f4538514118bff98a1bcd6481dd9a17067f8c9af77151621c9a5c/onnxruntime-1.24.3-cp313-cp313-win_amd64.whl", hash = "sha256:2d3706719be6ad41d38a2250998b1d87758a20f6ea4546962e21dc79f1f1fd2b", size = 12597939, upload-time = "2026-03-05T17:18:54.772Z" },
+    { url = "https://files.pythonhosted.org/packages/80/41/9696a5c4631a0caa75cc8bc4efd30938fd483694aa614898d087c3ee6d29/onnxruntime-1.24.3-cp313-cp313-win_arm64.whl", hash = "sha256:b082f3ba9519f0a1a1e754556bc7e635c7526ef81b98b3f78da4455d25f0437b", size = 12270705, upload-time = "2026-03-05T17:18:44.774Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/65/a26c5e59e3b210852ee04248cf8843c81fe7d40d94cf95343b66efe7eec9/onnxruntime-1.24.3-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72f956634bc2e4bd2e8b006bef111849bd42c42dea37bd0a4c728404fdaf4d34", size = 15161796, upload-time = "2026-03-05T16:35:02.871Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/25/2035b4aa2ccb5be6acf139397731ec507c5f09e199ab39d3262b22ffa1ac/onnxruntime-1.24.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78d1f25eed4ab9959db70a626ed50ee24cf497e60774f59f1207ac8556399c4d", size = 17240936, upload-time = "2026-03-05T17:18:09.534Z" },
 ]
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.39.1"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/b9/3161be15bb8e3ad01be8be5a968a9237c3027c5be504362ff800fca3e442/opentelemetry_api-1.39.1.tar.gz", hash = "sha256:fbde8c80e1b937a2c61f20347e91c0c18a1940cecf012d62e65a7caf08967c9c", size = 65767, upload-time = "2025-12-11T13:32:39.182Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/1d/4049a9e8698361cc1a1aa03a6c59e4fa4c71e0c0f94a30f988a6876a2ae6/opentelemetry_api-1.40.0.tar.gz", hash = "sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f", size = 70851, upload-time = "2026-03-04T14:17:21.555Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/df/d3f1ddf4bb4cb50ed9b1139cc7b1c54c34a1e7ce8fd1b9a37c0d1551a6bd/opentelemetry_api-1.39.1-py3-none-any.whl", hash = "sha256:2edd8463432a7f8443edce90972169b195e7d6a05500cd29e6d13898187c9950", size = 66356, upload-time = "2025-12-11T13:32:17.304Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/bf/93795954016c522008da367da292adceed71cca6ee1717e1d64c83089099/opentelemetry_api-1.40.0-py3-none-any.whl", hash = "sha256:82dd69331ae74b06f6a874704be0cfaa49a1650e1537d4a813b86ecef7d0ecf9", size = 68676, upload-time = "2026-03-04T14:17:01.24Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp"
-version = "1.39.1"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/9c/3ab1db90f32da200dba332658f2bbe602369e3d19f6aba394031a42635be/opentelemetry_exporter_otlp-1.39.1.tar.gz", hash = "sha256:7cf7470e9fd0060c8a38a23e4f695ac686c06a48ad97f8d4867bc9b420180b9c", size = 6147, upload-time = "2025-12-11T13:32:40.309Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/37/b6708e0eff5c5fb9aba2e0ea09f7f3bcbfd12a592d2a780241b5f6014df7/opentelemetry_exporter_otlp-1.40.0.tar.gz", hash = "sha256:7caa0870b95e2fcb59d64e16e2b639ecffb07771b6cd0000b5d12e5e4fef765a", size = 6152, upload-time = "2026-03-04T14:17:23.235Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/6c/bdc82a066e6fb1dcf9e8cc8d4e026358fe0f8690700cc6369a6bf9bd17a7/opentelemetry_exporter_otlp-1.39.1-py3-none-any.whl", hash = "sha256:68ae69775291f04f000eb4b698ff16ff685fdebe5cb52871bc4e87938a7b00fe", size = 7019, upload-time = "2025-12-11T13:32:19.387Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/fc/aea77c28d9f3ffef2fdafdc3f4a235aee4091d262ddabd25882f47ce5c5f/opentelemetry_exporter_otlp-1.40.0-py3-none-any.whl", hash = "sha256:48c87e539ec9afb30dc443775a1334cc5487de2f72a770a4c00b1610bf6c697d", size = 7023, upload-time = "2026-03-04T14:17:03.612Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.39.1"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-proto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/9d/22d241b66f7bbde88a3bfa6847a351d2c46b84de23e71222c6aae25c7050/opentelemetry_exporter_otlp_proto_common-1.39.1.tar.gz", hash = "sha256:763370d4737a59741c89a67b50f9e39271639ee4afc999dadfe768541c027464", size = 20409, upload-time = "2025-12-11T13:32:40.885Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/bc/1559d46557fe6eca0b46c88d4c2676285f1f3be2e8d06bb5d15fbffc814a/opentelemetry_exporter_otlp_proto_common-1.40.0.tar.gz", hash = "sha256:1cbee86a4064790b362a86601ee7934f368b81cd4cc2f2e163902a6e7818a0fa", size = 20416, upload-time = "2026-03-04T14:17:23.801Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/02/ffc3e143d89a27ac21fd557365b98bd0653b98de8a101151d5805b5d4c33/opentelemetry_exporter_otlp_proto_common-1.39.1-py3-none-any.whl", hash = "sha256:08f8a5862d64cc3435105686d0216c1365dc5701f86844a8cd56597d0c764fde", size = 18366, upload-time = "2025-12-11T13:32:20.2Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ca/8f122055c97a932311a3f640273f084e738008933503d0c2563cd5d591fc/opentelemetry_exporter_otlp_proto_common-1.40.0-py3-none-any.whl", hash = "sha256:7081ff453835a82417bf38dccf122c827c3cbc94f2079b03bba02a3165f25149", size = 18369, upload-time = "2026-03-04T14:17:04.796Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-grpc"
-version = "1.39.1"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -1822,14 +1728,14 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/48/b329fed2c610c2c32c9366d9dc597202c9d1e58e631c137ba15248d8850f/opentelemetry_exporter_otlp_proto_grpc-1.39.1.tar.gz", hash = "sha256:772eb1c9287485d625e4dbe9c879898e5253fea111d9181140f51291b5fec3ad", size = 24650, upload-time = "2025-12-11T13:32:41.429Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/7f/b9e60435cfcc7590fa87436edad6822240dddbc184643a2a005301cc31f4/opentelemetry_exporter_otlp_proto_grpc-1.40.0.tar.gz", hash = "sha256:bd4015183e40b635b3dab8da528b27161ba83bf4ef545776b196f0fb4ec47740", size = 25759, upload-time = "2026-03-04T14:17:24.4Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/a3/cc9b66575bd6597b98b886a2067eea2693408d2d5f39dad9ab7fc264f5f3/opentelemetry_exporter_otlp_proto_grpc-1.39.1-py3-none-any.whl", hash = "sha256:fa1c136a05c7e9b4c09f739469cbdb927ea20b34088ab1d959a849b5cc589c18", size = 19766, upload-time = "2025-12-11T13:32:21.027Z" },
+    { url = "https://files.pythonhosted.org/packages/96/6f/7ee0980afcbdcd2d40362da16f7f9796bd083bf7f0b8e038abfbc0300f5d/opentelemetry_exporter_otlp_proto_grpc-1.40.0-py3-none-any.whl", hash = "sha256:2aa0ca53483fe0cf6405087a7491472b70335bc5c7944378a0a8e72e86995c52", size = 20304, upload-time = "2026-03-04T14:17:05.942Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
-version = "1.39.1"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -1840,48 +1746,48 @@ dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/04/2a08fa9c0214ae38880df01e8bfae12b067ec0793446578575e5080d6545/opentelemetry_exporter_otlp_proto_http-1.39.1.tar.gz", hash = "sha256:31bdab9745c709ce90a49a0624c2bd445d31a28ba34275951a6a362d16a0b9cb", size = 17288, upload-time = "2025-12-11T13:32:42.029Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/fa/73d50e2c15c56be4d000c98e24221d494674b0cc95524e2a8cb3856d95a4/opentelemetry_exporter_otlp_proto_http-1.40.0.tar.gz", hash = "sha256:db48f5e0f33217588bbc00274a31517ba830da576e59503507c839b38fa0869c", size = 17772, upload-time = "2026-03-04T14:17:25.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/f1/b27d3e2e003cd9a3592c43d099d2ed8d0a947c15281bf8463a256db0b46c/opentelemetry_exporter_otlp_proto_http-1.39.1-py3-none-any.whl", hash = "sha256:d9f5207183dd752a412c4cd564ca8875ececba13be6e9c6c370ffb752fd59985", size = 19641, upload-time = "2025-12-11T13:32:22.248Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/3a/8865d6754e61c9fb170cdd530a124a53769ee5f740236064816eb0ca7301/opentelemetry_exporter_otlp_proto_http-1.40.0-py3-none-any.whl", hash = "sha256:a8d1dab28f504c5d96577d6509f80a8150e44e8f45f82cdbe0e34c99ab040069", size = 19960, upload-time = "2026-03-04T14:17:07.153Z" },
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "1.39.1"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/1d/f25d76d8260c156c40c97c9ed4511ec0f9ce353f8108ca6e7561f82a06b2/opentelemetry_proto-1.39.1.tar.gz", hash = "sha256:6c8e05144fc0d3ed4d22c2289c6b126e03bcd0e6a7da0f16cedd2e1c2772e2c8", size = 46152, upload-time = "2025-12-11T13:32:48.681Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/77/dd38991db037fdfce45849491cb61de5ab000f49824a00230afb112a4392/opentelemetry_proto-1.40.0.tar.gz", hash = "sha256:03f639ca129ba513f5819810f5b1f42bcb371391405d99c168fe6937c62febcd", size = 45667, upload-time = "2026-03-04T14:17:31.194Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/95/b40c96a7b5203005a0b03d8ce8cd212ff23f1793d5ba289c87a097571b18/opentelemetry_proto-1.39.1-py3-none-any.whl", hash = "sha256:22cdc78efd3b3765d09e68bfbd010d4fc254c9818afd0b6b423387d9dee46007", size = 72535, upload-time = "2025-12-11T13:32:33.866Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b2/189b2577dde745b15625b3214302605b1353436219d42b7912e77fa8dc24/opentelemetry_proto-1.40.0-py3-none-any.whl", hash = "sha256:266c4385d88923a23d63e353e9761af0f47a6ed0d486979777fe4de59dc9b25f", size = 72073, upload-time = "2026-03-04T14:17:16.673Z" },
 ]
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.39.1"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/fb/c76080c9ba07e1e8235d24cdcc4d125ef7aa3edf23eb4e497c2e50889adc/opentelemetry_sdk-1.39.1.tar.gz", hash = "sha256:cf4d4563caf7bff906c9f7967e2be22d0d6b349b908be0d90fb21c8e9c995cc6", size = 171460, upload-time = "2025-12-11T13:32:49.369Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/fd/3c3125b20ba18ce2155ba9ea74acb0ae5d25f8cd39cfd37455601b7955cc/opentelemetry_sdk-1.40.0.tar.gz", hash = "sha256:18e9f5ec20d859d268c7cb3c5198c8d105d073714db3de50b593b8c1345a48f2", size = 184252, upload-time = "2026-03-04T14:17:31.87Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/98/e91cf858f203d86f4eccdf763dcf01cf03f1dae80c3750f7e635bfa206b6/opentelemetry_sdk-1.39.1-py3-none-any.whl", hash = "sha256:4d5482c478513ecb0a5d938dcc61394e647066e0cc2676bee9f3af3f3f45f01c", size = 132565, upload-time = "2025-12-11T13:32:35.069Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c5/6a852903d8bfac758c6dc6e9a68b015d3c33f2f1be5e9591e0f4b69c7e0a/opentelemetry_sdk-1.40.0-py3-none-any.whl", hash = "sha256:787d2154a71f4b3d81f20524a8ce061b7db667d24e46753f32a7bc48f1c1f3f1", size = 141951, upload-time = "2026-03-04T14:17:17.961Z" },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.60b1"
+version = "0.61b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/df/553f93ed38bf22f4b999d9be9c185adb558982214f33eae539d3b5cd0858/opentelemetry_semantic_conventions-0.60b1.tar.gz", hash = "sha256:87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953", size = 137935, upload-time = "2025-12-11T13:32:50.487Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/c0/4ae7973f3c2cfd2b6e321f1675626f0dab0a97027cc7a297474c9c8f3d04/opentelemetry_semantic_conventions-0.61b0.tar.gz", hash = "sha256:072f65473c5d7c6dc0355b27d6c9d1a679d63b6d4b4b16a9773062cb7e31192a", size = 145755, upload-time = "2026-03-04T14:17:32.664Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/5e/5958555e09635d09b75de3c4f8b9cae7335ca545d77392ffe7331534c402/opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl", hash = "sha256:9fa8c8b0c110da289809292b0591220d3a7b53c1526a23021e977d68597893fb", size = 219982, upload-time = "2025-12-11T13:32:36.955Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/37/cc6a55e448deaa9b27377d087da8615a3416d8ad523d5960b78dbeadd02a/opentelemetry_semantic_conventions-0.61b0-py3-none-any.whl", hash = "sha256:fa530a96be229795f8cef353739b618148b0fe2b4b3f005e60e262926c4d38e2", size = 231621, upload-time = "2026-03-04T14:17:19.33Z" },
 ]
 
 [[package]]
@@ -1890,8 +1796,10 @@ version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
-    { name = "torch" },
-    { name = "torchaudio" },
+    { name = "torch", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "torchaudio", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "torchaudio", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
     { name = "tqdm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/ef/4ad54e3ecb1e89f7f7bdb4c7b751e43754e892d3c32a8550e5d0882565df/openunmix-1.3.0.tar.gz", hash = "sha256:cc9245ce728700f5d0b72c67f01be4162777e617cdc47f9b035963afac180fc8", size = 45889, upload-time = "2024-04-16T11:10:47.121Z" }
@@ -2017,11 +1925,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.9.2"
+version = "4.9.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/04/fea538adf7dbbd6d186f551d595961e564a3b6715bdf276b477460858672/platformdirs-4.9.2.tar.gz", hash = "sha256:9a33809944b9db043ad67ca0db94b14bf452cc6aeaac46a88ea55b26e2e9d291", size = 28394, upload-time = "2026-02-16T03:56:10.574Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/31/05e764397056194206169869b50cf2fee4dbbbc71b344705b9c0d878d4d8/platformdirs-4.9.2-py3-none-any.whl", hash = "sha256:9170634f126f8efdae22fb58ae8a0eaa86f38365bc57897a6c4f781d1f5875bd", size = 21168, upload-time = "2026-02-16T03:56:08.891Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
 ]
 
 [[package]]
@@ -2158,9 +2066,11 @@ dependencies = [
     { name = "pytorch-metric-learning" },
     { name = "rich" },
     { name = "safetensors" },
-    { name = "torch" },
+    { name = "torch", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
     { name = "torch-audiomentations" },
-    { name = "torchaudio" },
+    { name = "torchaudio", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "torchaudio", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
     { name = "torchcodec" },
     { name = "torchmetrics" },
 ]
@@ -2411,7 +2321,8 @@ dependencies = [
     { name = "lightning-utilities" },
     { name = "packaging" },
     { name = "pyyaml" },
-    { name = "torch" },
+    { name = "torch", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
     { name = "torchmetrics" },
     { name = "tqdm" },
     { name = "typing-extensions" },
@@ -2428,7 +2339,8 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "scikit-learn" },
-    { name = "torch" },
+    { name = "torch", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
     { name = "tqdm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9b/80/6e61b1a91debf4c1b47d441f9a9d7fe2aabcdd9575ed70b2811474eb95c3/pytorch-metric-learning-2.9.0.tar.gz", hash = "sha256:27a626caf5e2876a0fd666605a78cb67ef7597e25d7a68c18053dd503830701f", size = 84530, upload-time = "2025-08-17T17:11:19.501Z" }
@@ -2507,58 +2419,58 @@ wheels = [
 
 [[package]]
 name = "regex"
-version = "2026.2.19"
+version = "2026.2.28"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ff/c0/d8079d4f6342e4cec5c3e7d7415b5cd3e633d5f4124f7a4626908dbe84c7/regex-2026.2.19.tar.gz", hash = "sha256:6fb8cb09b10e38f3ae17cc6dc04a1df77762bd0351b6ba9041438e7cc85ec310", size = 414973, upload-time = "2026-02-19T19:03:47.899Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/71/41455aa99a5a5ac1eaf311f5d8efd9ce6433c03ac1e0962de163350d0d97/regex-2026.2.28.tar.gz", hash = "sha256:a729e47d418ea11d03469f321aaf67cdee8954cde3ff2cf8403ab87951ad10f2", size = 415184, upload-time = "2026-02-28T02:19:42.792Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/73/13b39c7c9356f333e564ab4790b6cb0df125b8e64e8d6474e73da49b1955/regex-2026.2.19-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c1665138776e4ac1aa75146669236f7a8a696433ec4e525abf092ca9189247cc", size = 489541, upload-time = "2026-02-19T19:00:52.728Z" },
-    { url = "https://files.pythonhosted.org/packages/15/77/fcc7bd9a67000d07fbcc11ed226077287a40d5c84544e62171d29d3ef59c/regex-2026.2.19-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d792b84709021945597e05656aac059526df4e0c9ef60a0eaebb306f8fafcaa8", size = 291414, upload-time = "2026-02-19T19:00:54.51Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/87/3997fc72dc59233426ef2e18dfdd105bb123812fff740ee9cc348f1a3243/regex-2026.2.19-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:db970bcce4d63b37b3f9eb8c893f0db980bbf1d404a1d8d2b17aa8189de92c53", size = 289140, upload-time = "2026-02-19T19:00:56.841Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/d0/b7dd3883ed1cff8ee0c0c9462d828aaf12be63bf5dc55453cbf423523b13/regex-2026.2.19-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:03d706fbe7dfec503c8c3cb76f9352b3e3b53b623672aa49f18a251a6c71b8e6", size = 798767, upload-time = "2026-02-19T19:00:59.014Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/7e/8e2d09103832891b2b735a2515abf377db21144c6dd5ede1fb03c619bf09/regex-2026.2.19-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8dbff048c042beef60aa1848961384572c5afb9e8b290b0f1203a5c42cf5af65", size = 864436, upload-time = "2026-02-19T19:01:00.772Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/2e/afea8d23a6db1f67f45e3a0da3057104ce32e154f57dd0c8997274d45fcd/regex-2026.2.19-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccaaf9b907ea6b4223d5cbf5fa5dff5f33dc66f4907a25b967b8a81339a6e332", size = 912391, upload-time = "2026-02-19T19:01:02.865Z" },
-    { url = "https://files.pythonhosted.org/packages/59/3c/ea5a4687adaba5e125b9bd6190153d0037325a0ba3757cc1537cc2c8dd90/regex-2026.2.19-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:75472631eee7898e16a8a20998d15106cb31cfde21cdf96ab40b432a7082af06", size = 803702, upload-time = "2026-02-19T19:01:05.298Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/c5/624a0705e8473a26488ec1a3a4e0b8763ecfc682a185c302dfec71daea35/regex-2026.2.19-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d89f85a5ccc0cec125c24be75610d433d65295827ebaf0d884cbe56df82d4774", size = 775980, upload-time = "2026-02-19T19:01:07.047Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/4b/ed776642533232b5599b7c1f9d817fe11faf597e8a92b7a44b841daaae76/regex-2026.2.19-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0d9f81806abdca3234c3dd582b8a97492e93de3602c8772013cb4affa12d1668", size = 788122, upload-time = "2026-02-19T19:01:08.744Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/58/e93e093921d13b9784b4f69896b6e2a9e09580a265c59d9eb95e87d288f2/regex-2026.2.19-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:9dadc10d1c2bbb1326e572a226d2ec56474ab8aab26fdb8cf19419b372c349a9", size = 858910, upload-time = "2026-02-19T19:01:10.488Z" },
-    { url = "https://files.pythonhosted.org/packages/85/77/ff1d25a0c56cd546e0455cbc93235beb33474899690e6a361fa6b52d265b/regex-2026.2.19-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6bc25d7e15f80c9dc7853cbb490b91c1ec7310808b09d56bd278fe03d776f4f6", size = 764153, upload-time = "2026-02-19T19:01:12.156Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/ef/8ec58df26d52d04443b1dc56f9be4b409f43ed5ae6c0248a287f52311fc4/regex-2026.2.19-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:965d59792f5037d9138da6fed50ba943162160443b43d4895b182551805aff9c", size = 850348, upload-time = "2026-02-19T19:01:14.147Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/b3/c42fd5ed91639ce5a4225b9df909180fc95586db071f2bf7c68d2ccbfbe6/regex-2026.2.19-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:38d88c6ed4a09ed61403dbdf515d969ccba34669af3961ceb7311ecd0cef504a", size = 789977, upload-time = "2026-02-19T19:01:15.838Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/22/bc3b58ebddbfd6ca5633e71fd41829ee931963aad1ebeec55aad0c23044e/regex-2026.2.19-cp312-cp312-win32.whl", hash = "sha256:5df947cabab4b643d4791af5e28aecf6bf62e6160e525651a12eba3d03755e6b", size = 266381, upload-time = "2026-02-19T19:01:17.952Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/4a/6ff550b63e67603ee60e69dc6bd2d5694e85046a558f663b2434bdaeb285/regex-2026.2.19-cp312-cp312-win_amd64.whl", hash = "sha256:4146dc576ea99634ae9c15587d0c43273b4023a10702998edf0fa68ccb60237a", size = 277274, upload-time = "2026-02-19T19:01:19.826Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/29/9ec48b679b1e87e7bc8517dff45351eab38f74fbbda1fbcf0e9e6d4e8174/regex-2026.2.19-cp312-cp312-win_arm64.whl", hash = "sha256:cdc0a80f679353bd68450d2a42996090c30b2e15ca90ded6156c31f1a3b63f3b", size = 270509, upload-time = "2026-02-19T19:01:22.075Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/2d/a849835e76ac88fcf9e8784e642d3ea635d183c4112150ca91499d6703af/regex-2026.2.19-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8df08decd339e8b3f6a2eb5c05c687fe9d963ae91f352bc57beb05f5b2ac6879", size = 489329, upload-time = "2026-02-19T19:01:23.841Z" },
-    { url = "https://files.pythonhosted.org/packages/da/aa/78ff4666d3855490bae87845a5983485e765e1f970da20adffa2937b241d/regex-2026.2.19-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3aa0944f1dc6e92f91f3b306ba7f851e1009398c84bfd370633182ee4fc26a64", size = 291308, upload-time = "2026-02-19T19:01:25.605Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/58/714384efcc07ae6beba528a541f6e99188c5cc1bc0295337f4e8a868296d/regex-2026.2.19-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c13228fbecb03eadbfd8f521732c5fda09ef761af02e920a3148e18ad0e09968", size = 289033, upload-time = "2026-02-19T19:01:27.243Z" },
-    { url = "https://files.pythonhosted.org/packages/75/ec/6438a9344d2869cf5265236a06af1ca6d885e5848b6561e10629bc8e5a11/regex-2026.2.19-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0d0e72703c60d68b18b27cde7cdb65ed2570ae29fb37231aa3076bfb6b1d1c13", size = 798798, upload-time = "2026-02-19T19:01:28.877Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/be/b1ce2d395e3fd2ce5f2fde2522f76cade4297cfe84cd61990ff48308749c/regex-2026.2.19-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:46e69a4bf552e30e74a8aa73f473c87efcb7f6e8c8ece60d9fd7bf13d5c86f02", size = 864444, upload-time = "2026-02-19T19:01:30.933Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/97/a3406460c504f7136f140d9461960c25f058b0240e4424d6fb73c7a067ab/regex-2026.2.19-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8edda06079bd770f7f0cf7f3bba1a0b447b96b4a543c91fe0c142d034c166161", size = 912633, upload-time = "2026-02-19T19:01:32.744Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/d9/e5dbef95008d84e9af1dc0faabbc34a7fbc8daa05bc5807c5cf86c2bec49/regex-2026.2.19-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9cbc69eae834afbf634f7c902fc72ff3e993f1c699156dd1af1adab5d06b7fe7", size = 803718, upload-time = "2026-02-19T19:01:34.61Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/e5/61d80132690a1ef8dc48e0f44248036877aebf94235d43f63a20d1598888/regex-2026.2.19-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bcf57d30659996ee5c7937999874504c11b5a068edc9515e6a59221cc2744dd1", size = 775975, upload-time = "2026-02-19T19:01:36.525Z" },
-    { url = "https://files.pythonhosted.org/packages/05/32/ae828b3b312c972cf228b634447de27237d593d61505e6ad84723f8eabba/regex-2026.2.19-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8e6e77cd92216eb489e21e5652a11b186afe9bdefca8a2db739fd6b205a9e0a4", size = 788129, upload-time = "2026-02-19T19:01:38.498Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/25/d74f34676f22bec401eddf0e5e457296941e10cbb2a49a571ca7a2c16e5a/regex-2026.2.19-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b9ab8dec42afefa6314ea9b31b188259ffdd93f433d77cad454cd0b8d235ce1c", size = 858818, upload-time = "2026-02-19T19:01:40.409Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/eb/0bc2b01a6b0b264e1406e5ef11cae3f634c3bd1a6e61206fd3227ce8e89c/regex-2026.2.19-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:294c0fb2e87c6bcc5f577c8f609210f5700b993151913352ed6c6af42f30f95f", size = 764186, upload-time = "2026-02-19T19:01:43.009Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/37/5fe5a630d0d99ecf0c3570f8905dafbc160443a2d80181607770086c9812/regex-2026.2.19-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:c0924c64b082d4512b923ac016d6e1dcf647a3560b8a4c7e55cbbd13656cb4ed", size = 850363, upload-time = "2026-02-19T19:01:45.015Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/45/ef68d805294b01ec030cfd388724ba76a5a21a67f32af05b17924520cb0b/regex-2026.2.19-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:790dbf87b0361606cb0d79b393c3e8f4436a14ee56568a7463014565d97da02a", size = 790026, upload-time = "2026-02-19T19:01:47.51Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/3a/40d3b66923dfc5aeba182f194f0ca35d09afe8c031a193e6ae46971a0a0e/regex-2026.2.19-cp313-cp313-win32.whl", hash = "sha256:43cdde87006271be6963896ed816733b10967baaf0e271d529c82e93da66675b", size = 266372, upload-time = "2026-02-19T19:01:49.469Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/f2/39082e8739bfd553497689e74f9d5e5bb531d6f8936d0b94f43e18f219c0/regex-2026.2.19-cp313-cp313-win_amd64.whl", hash = "sha256:127ea69273485348a126ebbf3d6052604d3c7da284f797bba781f364c0947d47", size = 277253, upload-time = "2026-02-19T19:01:51.208Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/c2/852b9600d53fb47e47080c203e2cdc0ac7e84e37032a57e0eaa37446033a/regex-2026.2.19-cp313-cp313-win_arm64.whl", hash = "sha256:5e56c669535ac59cbf96ca1ece0ef26cb66809990cda4fa45e1e32c3b146599e", size = 270505, upload-time = "2026-02-19T19:01:52.865Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/a2/e0b4575b93bc84db3b1fab24183e008691cd2db5c0ef14ed52681fbd94dd/regex-2026.2.19-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:93d881cab5afdc41a005dba1524a40947d6f7a525057aa64aaf16065cf62faa9", size = 492202, upload-time = "2026-02-19T19:01:54.816Z" },
-    { url = "https://files.pythonhosted.org/packages/24/b5/b84fec8cbb5f92a7eed2b6b5353a6a9eed9670fee31817c2da9eb85dc797/regex-2026.2.19-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:80caaa1ddcc942ec7be18427354f9d58a79cee82dea2a6b3d4fd83302e1240d7", size = 292884, upload-time = "2026-02-19T19:01:58.254Z" },
-    { url = "https://files.pythonhosted.org/packages/70/0c/fe89966dfae43da46f475362401f03e4d7dc3a3c955b54f632abc52669e0/regex-2026.2.19-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:d793c5b4d2b4c668524cd1651404cfc798d40694c759aec997e196fe9729ec60", size = 291236, upload-time = "2026-02-19T19:01:59.966Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/f7/bda2695134f3e63eb5cccbbf608c2a12aab93d261ff4e2fe49b47fabc948/regex-2026.2.19-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b5100acb20648d9efd3f4e7e91f51187f95f22a741dcd719548a6cf4e1b34b3f", size = 807660, upload-time = "2026-02-19T19:02:01.632Z" },
-    { url = "https://files.pythonhosted.org/packages/11/56/6e3a4bf5e60d17326b7003d91bbde8938e439256dec211d835597a44972d/regex-2026.2.19-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5e3a31e94d10e52a896adaa3adf3621bd526ad2b45b8c2d23d1bbe74c7423007", size = 873585, upload-time = "2026-02-19T19:02:03.522Z" },
-    { url = "https://files.pythonhosted.org/packages/35/5e/c90c6aa4d1317cc11839359479cfdd2662608f339e84e81ba751c8a4e461/regex-2026.2.19-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8497421099b981f67c99eba4154cf0dfd8e47159431427a11cfb6487f7791d9e", size = 915243, upload-time = "2026-02-19T19:02:05.608Z" },
-    { url = "https://files.pythonhosted.org/packages/90/7c/981ea0694116793001496aaf9524e5c99e122ec3952d9e7f1878af3a6bf1/regex-2026.2.19-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1e7a08622f7d51d7a068f7e4052a38739c412a3e74f55817073d2e2418149619", size = 812922, upload-time = "2026-02-19T19:02:08.115Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/be/9eda82afa425370ffdb3fa9f3ea42450b9ae4da3ff0a4ec20466f69e371b/regex-2026.2.19-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8abe671cf0f15c26b1ad389bf4043b068ce7d3b1c5d9313e12895f57d6738555", size = 781318, upload-time = "2026-02-19T19:02:10.072Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/d5/50f0bbe56a8199f60a7b6c714e06e54b76b33d31806a69d0703b23ce2a9e/regex-2026.2.19-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5a8f28dd32a4ce9c41758d43b5b9115c1c497b4b1f50c457602c1d571fa98ce1", size = 795649, upload-time = "2026-02-19T19:02:11.96Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/09/d039f081e44a8b0134d0bb2dd805b0ddf390b69d0b58297ae098847c572f/regex-2026.2.19-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:654dc41a5ba9b8cc8432b3f1aa8906d8b45f3e9502442a07c2f27f6c63f85db5", size = 868844, upload-time = "2026-02-19T19:02:14.043Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/53/e2903b79a19ec8557fe7cd21cd093956ff2dbc2e0e33969e3adbe5b184dd/regex-2026.2.19-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:4a02faea614e7fdd6ba8b3bec6c8e79529d356b100381cec76e638f45d12ca04", size = 770113, upload-time = "2026-02-19T19:02:16.161Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/e2/784667767b55714ebb4e59bf106362327476b882c0b2f93c25e84cc99b1a/regex-2026.2.19-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:d96162140bb819814428800934c7b71b7bffe81fb6da2d6abc1dcca31741eca3", size = 854922, upload-time = "2026-02-19T19:02:18.155Z" },
-    { url = "https://files.pythonhosted.org/packages/59/78/9ef4356bd4aed752775bd18071034979b85f035fec51f3a4f9dea497a254/regex-2026.2.19-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c227f2922153ee42bbeb355fd6d009f8c81d9d7bdd666e2276ce41f53ed9a743", size = 799636, upload-time = "2026-02-19T19:02:20.04Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/54/fcfc9287f20c5c9bd8db755aafe3e8cf4d99a6a3f1c7162ee182e0ca9374/regex-2026.2.19-cp313-cp313t-win32.whl", hash = "sha256:a178df8ec03011153fbcd2c70cb961bc98cbbd9694b28f706c318bee8927c3db", size = 268968, upload-time = "2026-02-19T19:02:22.816Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/a0/ff24c6cb1273e42472706d277147fc38e1f9074a280fb6034b0fc9b69415/regex-2026.2.19-cp313-cp313t-win_amd64.whl", hash = "sha256:2c1693ca6f444d554aa246b592355b5cec030ace5a2729eae1b04ab6e853e768", size = 280390, upload-time = "2026-02-19T19:02:25.231Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/b6/a3f6ad89d780ffdeebb4d5e2e3e30bd2ef1f70f6a94d1760e03dd1e12c60/regex-2026.2.19-cp313-cp313t-win_arm64.whl", hash = "sha256:c0761d7ae8d65773e01515ebb0b304df1bf37a0a79546caad9cbe79a42c12af7", size = 271643, upload-time = "2026-02-19T19:02:27.175Z" },
+    { url = "https://files.pythonhosted.org/packages/07/42/9061b03cf0fc4b5fa2c3984cbbaed54324377e440a5c5a29d29a72518d62/regex-2026.2.28-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fcf26c3c6d0da98fada8ae4ef0aa1c3405a431c0a77eb17306d38a89b02adcd7", size = 489574, upload-time = "2026-02-28T02:16:50.455Z" },
+    { url = "https://files.pythonhosted.org/packages/77/83/0c8a5623a233015595e3da499c5a1c13720ac63c107897a6037bb97af248/regex-2026.2.28-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:02473c954af35dd2defeb07e44182f5705b30ea3f351a7cbffa9177beb14da5d", size = 291426, upload-time = "2026-02-28T02:16:52.52Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/06/3ef1ac6910dc3295ebd71b1f9bfa737e82cfead211a18b319d45f85ddd09/regex-2026.2.28-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9b65d33a17101569f86d9c5966a8b1d7fbf8afdda5a8aa219301b0a80f58cf7d", size = 289200, upload-time = "2026-02-28T02:16:54.08Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c9/8cc8d850b35ab5650ff6756a1cb85286e2000b66c97520b29c1587455344/regex-2026.2.28-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e71dcecaa113eebcc96622c17692672c2d104b1d71ddf7adeda90da7ddeb26fc", size = 796765, upload-time = "2026-02-28T02:16:55.905Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5d/57702597627fc23278ebf36fbb497ac91c0ce7fec89ac6c81e420ca3e38c/regex-2026.2.28-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:481df4623fa4969c8b11f3433ed7d5e3dc9cec0f008356c3212b3933fb77e3d8", size = 863093, upload-time = "2026-02-28T02:16:58.094Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/f3ecad537ca2811b4d26b54ca848cf70e04fcfc138667c146a9f3157779c/regex-2026.2.28-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:64e7c6ad614573e0640f271e811a408d79a9e1fe62a46adb602f598df42a818d", size = 909455, upload-time = "2026-02-28T02:17:00.918Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/40/bb226f203caa22c1043c1ca79b36340156eca0f6a6742b46c3bb222a3a57/regex-2026.2.28-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6b08a06976ff4fb0d83077022fde3eca06c55432bb997d8c0495b9a4e9872f4", size = 802037, upload-time = "2026-02-28T02:17:02.842Z" },
+    { url = "https://files.pythonhosted.org/packages/44/7c/c6d91d8911ac6803b45ca968e8e500c46934e58c0903cbc6d760ee817a0a/regex-2026.2.28-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:864cdd1a2ef5716b0ab468af40139e62ede1b3a53386b375ec0786bb6783fc05", size = 775113, upload-time = "2026-02-28T02:17:04.506Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8d/4a9368d168d47abd4158580b8c848709667b1cd293ff0c0c277279543bd0/regex-2026.2.28-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:511f7419f7afab475fd4d639d4aedfc54205bcb0800066753ef68a59f0f330b5", size = 784194, upload-time = "2026-02-28T02:17:06.888Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/bf/2c72ab5d8b7be462cb1651b5cc333da1d0068740342f350fcca3bca31947/regex-2026.2.28-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b42f7466e32bf15a961cf09f35fa6323cc72e64d3d2c990b10de1274a5da0a59", size = 856846, upload-time = "2026-02-28T02:17:09.11Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f4/6b65c979bb6d09f51bb2d2a7bc85de73c01ec73335d7ddd202dcb8cd1c8f/regex-2026.2.28-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:8710d61737b0c0ce6836b1da7109f20d495e49b3809f30e27e9560be67a257bf", size = 763516, upload-time = "2026-02-28T02:17:11.004Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/32/29ea5e27400ee86d2cc2b4e80aa059df04eaf78b4f0c18576ae077aeff68/regex-2026.2.28-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:4390c365fd2d45278f45afd4673cb90f7285f5701607e3ad4274df08e36140ae", size = 849278, upload-time = "2026-02-28T02:17:12.693Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/91/3233d03b5f865111cd517e1c95ee8b43e8b428d61fa73764a80c9bb6f537/regex-2026.2.28-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:cb3b1db8ff6c7b8bf838ab05583ea15230cb2f678e569ab0e3a24d1e8320940b", size = 790068, upload-time = "2026-02-28T02:17:14.9Z" },
+    { url = "https://files.pythonhosted.org/packages/76/92/abc706c1fb03b4580a09645b206a3fc032f5a9f457bc1a8038ac555658ab/regex-2026.2.28-cp312-cp312-win32.whl", hash = "sha256:f8ed9a5d4612df9d4de15878f0bc6aa7a268afbe5af21a3fdd97fa19516e978c", size = 266416, upload-time = "2026-02-28T02:17:17.15Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/06/2a6f7dff190e5fa9df9fb4acf2fdf17a1aa0f7f54596cba8de608db56b3a/regex-2026.2.28-cp312-cp312-win_amd64.whl", hash = "sha256:01d65fd24206c8e1e97e2e31b286c59009636c022eb5d003f52760b0f42155d4", size = 277297, upload-time = "2026-02-28T02:17:18.723Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f0/58a2484851fadf284458fdbd728f580d55c1abac059ae9f048c63b92f427/regex-2026.2.28-cp312-cp312-win_arm64.whl", hash = "sha256:c0b5ccbb8ffb433939d248707d4a8b31993cb76ab1a0187ca886bf50e96df952", size = 270408, upload-time = "2026-02-28T02:17:20.328Z" },
+    { url = "https://files.pythonhosted.org/packages/87/f6/dc9ef48c61b79c8201585bf37fa70cd781977da86e466cd94e8e95d2443b/regex-2026.2.28-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6d63a07e5ec8ce7184452cb00c41c37b49e67dc4f73b2955b5b8e782ea970784", size = 489311, upload-time = "2026-02-28T02:17:22.591Z" },
+    { url = "https://files.pythonhosted.org/packages/95/c8/c20390f2232d3f7956f420f4ef1852608ad57aa26c3dd78516cb9f3dc913/regex-2026.2.28-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e59bc8f30414d283ae8ee1617b13d8112e7135cb92830f0ec3688cb29152585a", size = 291285, upload-time = "2026-02-28T02:17:24.355Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/a6/ba1068a631ebd71a230e7d8013fcd284b7c89c35f46f34a7da02082141b1/regex-2026.2.28-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:de0cf053139f96219ccfabb4a8dd2d217c8c82cb206c91d9f109f3f552d6b43d", size = 289051, upload-time = "2026-02-28T02:17:26.722Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/1b/7cc3b7af4c244c204b7a80924bd3d85aecd9ba5bc82b485c5806ee8cda9e/regex-2026.2.28-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb4db2f17e6484904f986c5a657cec85574c76b5c5e61c7aae9ffa1bc6224f95", size = 796842, upload-time = "2026-02-28T02:17:29.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/87/26bd03efc60e0d772ac1e7b60a2e6325af98d974e2358f659c507d3c76db/regex-2026.2.28-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:52b017b35ac2214d0db5f4f90e303634dc44e4aba4bd6235a27f97ecbe5b0472", size = 863083, upload-time = "2026-02-28T02:17:31.363Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/54/aeaf4afb1aa0a65e40de52a61dc2ac5b00a83c6cb081c8a1d0dda74f3010/regex-2026.2.28-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:69fc560ccbf08a09dc9b52ab69cacfae51e0ed80dc5693078bdc97db2f91ae96", size = 909412, upload-time = "2026-02-28T02:17:33.248Z" },
+    { url = "https://files.pythonhosted.org/packages/12/2f/049901def913954e640d199bbc6a7ca2902b6aeda0e5da9d17f114100ec2/regex-2026.2.28-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e61eea47230eba62a31f3e8a0e3164d0f37ef9f40529fb2c79361bc6b53d2a92", size = 802101, upload-time = "2026-02-28T02:17:35.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/a5/512fb9ff7f5b15ea204bb1967ebb649059446decacccb201381f9fa6aad4/regex-2026.2.28-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4f5c0b182ad4269e7381b7c27fdb0408399881f7a92a4624fd5487f2971dfc11", size = 775260, upload-time = "2026-02-28T02:17:37.692Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/9a92935878aba19bd72706b9db5646a6f993d99b3f6ed42c02ec8beb1d61/regex-2026.2.28-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:96f6269a2882fbb0ee76967116b83679dc628e68eaea44e90884b8d53d833881", size = 784311, upload-time = "2026-02-28T02:17:39.855Z" },
+    { url = "https://files.pythonhosted.org/packages/09/d3/fc51a8a738a49a6b6499626580554c9466d3ea561f2b72cfdc72e4149773/regex-2026.2.28-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b5acd4b6a95f37c3c3828e5d053a7d4edaedb85de551db0153754924cb7c83e3", size = 856876, upload-time = "2026-02-28T02:17:42.317Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b7/2e641f3d084b120ca4c52e8c762a78da0b32bf03ef546330db3e2635dc5f/regex-2026.2.28-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2234059cfe33d9813a3677ef7667999caea9eeaa83fef98eb6ce15c6cf9e0215", size = 763632, upload-time = "2026-02-28T02:17:45.073Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/6d/0009021d97e79ee99f3d8641f0a8d001eed23479ade4c3125a5480bf3e2d/regex-2026.2.28-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:c15af43c72a7fb0c97cbc66fa36a43546eddc5c06a662b64a0cbf30d6ac40944", size = 849320, upload-time = "2026-02-28T02:17:47.192Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7a/51cfbad5758f8edae430cb21961a9c8d04bce1dae4d2d18d4186eec7cfa1/regex-2026.2.28-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9185cc63359862a6e80fe97f696e04b0ad9a11c4ac0a4a927f979f611bfe3768", size = 790152, upload-time = "2026-02-28T02:17:49.067Z" },
+    { url = "https://files.pythonhosted.org/packages/90/3d/a83e2b6b3daa142acb8c41d51de3876186307d5cb7490087031747662500/regex-2026.2.28-cp313-cp313-win32.whl", hash = "sha256:fb66e5245db9652abd7196ace599b04d9c0e4aa7c8f0e2803938377835780081", size = 266398, upload-time = "2026-02-28T02:17:50.744Z" },
+    { url = "https://files.pythonhosted.org/packages/85/4f/16e9ebb1fe5425e11b9596c8d57bf8877dcb32391da0bfd33742e3290637/regex-2026.2.28-cp313-cp313-win_amd64.whl", hash = "sha256:71a911098be38c859ceb3f9a9ce43f4ed9f4c6720ad8684a066ea246b76ad9ff", size = 277282, upload-time = "2026-02-28T02:17:53.074Z" },
+    { url = "https://files.pythonhosted.org/packages/07/b4/92851335332810c5a89723bf7a7e35c7209f90b7d4160024501717b28cc9/regex-2026.2.28-cp313-cp313-win_arm64.whl", hash = "sha256:39bb5727650b9a0275c6a6690f9bb3fe693a7e6cc5c3155b1240aedf8926423e", size = 270382, upload-time = "2026-02-28T02:17:54.888Z" },
+    { url = "https://files.pythonhosted.org/packages/24/07/6c7e4cec1e585959e96cbc24299d97e4437a81173217af54f1804994e911/regex-2026.2.28-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:97054c55db06ab020342cc0d35d6f62a465fa7662871190175f1ad6c655c028f", size = 492541, upload-time = "2026-02-28T02:17:56.813Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/13/55eb22ada7f43d4f4bb3815b6132183ebc331c81bd496e2d1f3b8d862e0d/regex-2026.2.28-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0d25a10811de831c2baa6aef3c0be91622f44dd8d31dd12e69f6398efb15e48b", size = 292984, upload-time = "2026-02-28T02:17:58.538Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/c301f8cb29ce9644a5ef85104c59244e6e7e90994a0f458da4d39baa8e17/regex-2026.2.28-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:d6cfe798d8da41bb1862ed6e0cba14003d387c3c0c4a5d45591076ae9f0ce2f8", size = 291509, upload-time = "2026-02-28T02:18:00.208Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/43/aabe384ec1994b91796e903582427bc2ffaed9c4103819ed3c16d8e749f3/regex-2026.2.28-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fd0ce43e71d825b7c0661f9c54d4d74bd97c56c3fd102a8985bcfea48236bacb", size = 809429, upload-time = "2026-02-28T02:18:02.328Z" },
+    { url = "https://files.pythonhosted.org/packages/04/b8/8d2d987a816720c4f3109cee7c06a4b24ad0e02d4fc74919ab619e543737/regex-2026.2.28-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:00945d007fd74a9084d2ab79b695b595c6b7ba3698972fadd43e23230c6979c1", size = 869422, upload-time = "2026-02-28T02:18:04.23Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/ad/2c004509e763c0c3719f97c03eca26473bffb3868d54c5f280b8cd4f9e3d/regex-2026.2.28-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bec23c11cbbf09a4df32fe50d57cbdd777bc442269b6e39a1775654f1c95dee2", size = 915175, upload-time = "2026-02-28T02:18:06.791Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c2/fd429066da487ef555a9da73bf214894aec77fc8c66a261ee355a69871a8/regex-2026.2.28-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5cdcc17d935c8f9d3f4db5c2ebe2640c332e3822ad5d23c2f8e0228e6947943a", size = 812044, upload-time = "2026-02-28T02:18:08.736Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/ca/feedb7055c62a3f7f659971bf45f0e0a87544b6b0cf462884761453f97c5/regex-2026.2.28-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a448af01e3d8031c89c5d902040b124a5e921a25c4e5e07a861ca591ce429341", size = 782056, upload-time = "2026-02-28T02:18:10.777Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/1aa959ed0d25c1dd7dd5047ea8ba482ceaef38ce363c401fd32a6b923e60/regex-2026.2.28-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:10d28e19bd4888e4abf43bd3925f3c134c52fdf7259219003588a42e24c2aa25", size = 798743, upload-time = "2026-02-28T02:18:13.025Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/1f/dadb9cf359004784051c897dcf4d5d79895f73a1bbb7b827abaa4814ae80/regex-2026.2.28-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:99985a2c277dcb9ccb63f937451af5d65177af1efdeb8173ac55b61095a0a05c", size = 864633, upload-time = "2026-02-28T02:18:16.84Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f1/b9a25eb24e1cf79890f09e6ec971ee5b511519f1851de3453bc04f6c902b/regex-2026.2.28-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:e1e7b24cb3ae9953a560c563045d1ba56ee4749fbd05cf21ba571069bd7be81b", size = 770862, upload-time = "2026-02-28T02:18:18.892Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/c5cb10b7aa6f182f9247a30cc9527e326601f46f4df864ac6db588d11fcd/regex-2026.2.28-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:d8511a01d0e4ee1992eb3ba19e09bc1866fe03f05129c3aec3fdc4cbc77aad3f", size = 854788, upload-time = "2026-02-28T02:18:21.475Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/50/414ba0731c4bd40b011fa4703b2cc86879ec060c64f2a906e65a56452589/regex-2026.2.28-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:aaffaecffcd2479ce87aa1e74076c221700b7c804e48e98e62500ee748f0f550", size = 800184, upload-time = "2026-02-28T02:18:23.492Z" },
+    { url = "https://files.pythonhosted.org/packages/69/50/0c7290987f97e7e6830b0d853f69dc4dc5852c934aae63e7fdcd76b4c383/regex-2026.2.28-cp313-cp313t-win32.whl", hash = "sha256:ef77bdde9c9eba3f7fa5b58084b29bbcc74bcf55fdbeaa67c102a35b5bd7e7cc", size = 269137, upload-time = "2026-02-28T02:18:25.375Z" },
+    { url = "https://files.pythonhosted.org/packages/68/80/ef26ff90e74ceb4051ad6efcbbb8a4be965184a57e879ebcbdef327d18fa/regex-2026.2.28-cp313-cp313t-win_amd64.whl", hash = "sha256:98adf340100cbe6fbaf8e6dc75e28f2c191b1be50ffefe292fb0e6f6eefdb0d8", size = 280682, upload-time = "2026-02-28T02:18:27.205Z" },
+    { url = "https://files.pythonhosted.org/packages/69/8b/fbad9c52e83ffe8f97e3ed1aa0516e6dff6bb633a41da9e64645bc7efdc5/regex-2026.2.28-cp313-cp313t-win_arm64.whl", hash = "sha256:2fb950ac1d88e6b6a9414381f403797b236f9fa17e1eee07683af72b1634207b", size = 271735, upload-time = "2026-02-28T02:18:29.015Z" },
 ]
 
 [[package]]
@@ -2695,11 +2607,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.0"
+version = "82.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/f3/748f4d6f65d1756b9ae577f329c951cda23fb900e4de9f70900ced962085/setuptools-82.0.0.tar.gz", hash = "sha256:22e0a2d69474c6ae4feb01951cb69d515ed23728cf96d05513d36e42b62b37cb", size = 1144893, upload-time = "2026-02-08T15:08:40.206Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/c6/76dc613121b793286a3f91621d7b75a2b493e0390ddca50f11993eadf192/setuptools-82.0.0-py3-none-any.whl", hash = "sha256:70b18734b607bd1da571d097d236cfcfacaf01de45717d59e6e04b96877532e0", size = 1003468, upload-time = "2026-02-08T15:08:38.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
 ]
 
 [[package]]
@@ -2757,35 +2669,35 @@ wheels = [
 
 [[package]]
 name = "sqlalchemy"
-version = "2.0.47"
+version = "2.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/4b/1e00561093fe2cd8eef09d406da003c8a118ff02d6548498c1ae677d68d9/sqlalchemy-2.0.47.tar.gz", hash = "sha256:e3e7feb57b267fe897e492b9721ae46d5c7de6f9e8dee58aacf105dc4e154f3d", size = 9886323, upload-time = "2026-02-24T16:34:27.947Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/73/b4a9737255583b5fa858e0bb8e116eb94b88c910164ed2ed719147bde3de/sqlalchemy-2.0.48.tar.gz", hash = "sha256:5ca74f37f3369b45e1f6b7b06afb182af1fd5dde009e4ffd831830d98cbe5fe7", size = 9886075, upload-time = "2026-03-02T15:28:51.474Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/88/74eb470223ff88ea6572a132c0b8de8c1d8ed7b843d3b44a8a3c77f31d39/sqlalchemy-2.0.47-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4fa91b19d6b9821c04cc8f7aa2476429cc8887b9687c762815aa629f5c0edec1", size = 2155687, upload-time = "2026-02-24T17:05:46.451Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/ba/1447d3d558971b036cb93b557595cb5dcdfe728f1c7ac4dec16505ef5756/sqlalchemy-2.0.47-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7c5bbbd14eff577c8c79cbfe39a0771eecd20f430f3678533476f0087138f356", size = 3336978, upload-time = "2026-02-24T17:18:04.597Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/07/b47472d2ffd0776826f17ccf0b4d01b224c99fbd1904aeb103dffbb4b1cc/sqlalchemy-2.0.47-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5a6c555da8d4280a3c4c78c5b7a3f990cee2b2884e5f934f87a226191682ff7", size = 3349939, upload-time = "2026-02-24T17:27:18.937Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/c6/95fa32b79b57769da3e16f054cf658d90940317b5ca0ec20eac84aa19c4f/sqlalchemy-2.0.47-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ed48a1701d24dff3bb49a5bce94d6bc84cbe33d98af2aa2d3cdcce3dea1709ec", size = 3279648, upload-time = "2026-02-24T17:18:07.038Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/c8/3d07e7c73928dc59a0bed40961ca4e313e797bce650b088e8d5fdd3ad939/sqlalchemy-2.0.47-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4f3178c920ad98158f0b6309382194df04b14808fa6052ae07099fdde29d5602", size = 3314695, upload-time = "2026-02-24T17:27:20.93Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/d2/ed32b1611c1e19fdb028eee1adc5a9aa138c2952d09ae11f1670170f80ae/sqlalchemy-2.0.47-cp312-cp312-win32.whl", hash = "sha256:b9c11ac9934dd59ece9619fe42780a08abe2faab7b0543bb00d5eabea4f421b9", size = 2115502, upload-time = "2026-02-24T17:22:52.546Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/52/9de590356a4dd8e9ef5a881dbba64b2bbc4cbc71bf02bc68e775fb9b1899/sqlalchemy-2.0.47-cp312-cp312-win_amd64.whl", hash = "sha256:db43b72cf8274a99e089755c9c1e0b947159b71adbc2c83c3de2e38d5d607acb", size = 2142435, upload-time = "2026-02-24T17:22:54.268Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/e5/0af64ce7d8f60ec5328c10084e2f449e7912a9b8bdbefdcfb44454a25f49/sqlalchemy-2.0.47-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:456a135b790da5d3c6b53d0ef71ac7b7d280b7f41eb0c438986352bf03ca7143", size = 2152551, upload-time = "2026-02-24T17:05:47.675Z" },
-    { url = "https://files.pythonhosted.org/packages/63/79/746b8d15f6940e2ac469ce22d7aa5b1124b1ab820bad9b046eb3000c88a6/sqlalchemy-2.0.47-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:09a2f7698e44b3135433387da5d8846cf7cc7c10e5425af7c05fee609df978b6", size = 3278782, upload-time = "2026-02-24T17:18:10.012Z" },
-    { url = "https://files.pythonhosted.org/packages/91/b1/bd793ddb34345d1ed43b13ab2d88c95d7d4eb2e28f5b5a99128b9cc2bca2/sqlalchemy-2.0.47-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0bbc72e6a177c78d724f9106aaddc0d26a2ada89c6332b5935414eccf04cbd5", size = 3295155, upload-time = "2026-02-24T17:27:22.827Z" },
-    { url = "https://files.pythonhosted.org/packages/97/84/7213def33f94e5ca6f5718d259bc9f29de0363134648425aa218d4356b23/sqlalchemy-2.0.47-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:75460456b043b78b6006e41bdf5b86747ee42eafaf7fffa3b24a6e9a456a2092", size = 3226834, upload-time = "2026-02-24T17:18:11.465Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/06/456810204f4dc29b5f025b1b0a03b4bd6b600ebf3c1040aebd90a257fa33/sqlalchemy-2.0.47-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5d9adaa616c3bc7d80f9ded57cd84b51d6617cad6a5456621d858c9f23aaee01", size = 3265001, upload-time = "2026-02-24T17:27:24.813Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/20/df3920a4b2217dbd7390a5bd277c1902e0393f42baaf49f49b3c935e7328/sqlalchemy-2.0.47-cp313-cp313-win32.whl", hash = "sha256:76e09f974382a496a5ed985db9343628b1cb1ac911f27342e4cc46a8bac10476", size = 2113647, upload-time = "2026-02-24T17:22:55.747Z" },
-    { url = "https://files.pythonhosted.org/packages/46/06/7873ddf69918efbfabd7211829f4bd8019739d0a719253112d305d3ba51d/sqlalchemy-2.0.47-cp313-cp313-win_amd64.whl", hash = "sha256:0664089b0bf6724a0bfb49a0cf4d4da24868a0a5c8e937cd7db356d5dcdf2c66", size = 2139425, upload-time = "2026-02-24T17:22:57.033Z" },
-    { url = "https://files.pythonhosted.org/packages/54/fa/61ad9731370c90ac7ea5bf8f5eaa12c48bb4beec41c0fa0360becf4ac10d/sqlalchemy-2.0.47-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ed0c967c701ae13da98eb220f9ddab3044ab63504c1ba24ad6a59b26826ad003", size = 3558809, upload-time = "2026-02-24T17:12:15.232Z" },
-    { url = "https://files.pythonhosted.org/packages/33/d5/221fac96f0529391fe374875633804c866f2b21a9c6d3a6ca57d9c12cfd7/sqlalchemy-2.0.47-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3537943a61fd25b241e976426a0c6814434b93cf9b09d39e8e78f3c9eb9a487", size = 3525480, upload-time = "2026-02-24T17:27:59.602Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/55/8247d53998c3673e4a8d1958eba75c6f5cc3b39082029d400bb1f2a911ae/sqlalchemy-2.0.47-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:57f7e336a64a0dba686c66392d46b9bc7af2c57d55ce6dc1697b4ef32b043ceb", size = 3466569, upload-time = "2026-02-24T17:12:16.94Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/b5/c1f0eea1bac6790845f71420a7fe2f2a0566203aa57543117d4af3b77d1c/sqlalchemy-2.0.47-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dff735a621858680217cb5142b779bad40ef7322ddbb7c12062190db6879772e", size = 3475770, upload-time = "2026-02-24T17:28:02.034Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/ed/2f43f92474ea0c43c204657dc47d9d002cd738b96ca2af8e6d29a9b5e42d/sqlalchemy-2.0.47-cp313-cp313t-win32.whl", hash = "sha256:3893dc096bb3cca9608ea3487372ffcea3ae9b162f40e4d3c51dd49db1d1b2dc", size = 2141300, upload-time = "2026-02-24T17:14:37.024Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/a9/8b73f9f1695b6e92f7aaf1711135a1e3bbeb78bca9eded35cb79180d3c6d/sqlalchemy-2.0.47-cp313-cp313t-win_amd64.whl", hash = "sha256:b5103427466f4b3e61f04833ae01f9a914b1280a2a8bcde3a9d7ab11f3755b42", size = 2173053, upload-time = "2026-02-24T17:14:38.688Z" },
-    { url = "https://files.pythonhosted.org/packages/15/9f/7c378406b592fcf1fc157248607b495a40e3202ba4a6f1372a2ba6447717/sqlalchemy-2.0.47-py3-none-any.whl", hash = "sha256:e2647043599297a1ef10e720cf310846b7f31b6c841fee093d2b09d81215eb93", size = 1940159, upload-time = "2026-02-24T17:15:07.158Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/91/a42ae716f8925e9659df2da21ba941f158686856107a61cc97a95e7647a3/sqlalchemy-2.0.48-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:348174f228b99f33ca1f773e85510e08927620caa59ffe7803b37170df30332b", size = 2155737, upload-time = "2026-03-02T15:49:13.207Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/52/f75f516a1f3888f027c1cfb5d22d4376f4b46236f2e8669dcb0cddc60275/sqlalchemy-2.0.48-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53667b5f668991e279d21f94ccfa6e45b4e3f4500e7591ae59a8012d0f010dcb", size = 3337020, upload-time = "2026-03-02T15:50:34.547Z" },
+    { url = "https://files.pythonhosted.org/packages/37/9a/0c28b6371e0cdcb14f8f1930778cb3123acfcbd2c95bb9cf6b4a2ba0cce3/sqlalchemy-2.0.48-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34634e196f620c7a61d18d5cf7dc841ca6daa7961aed75d532b7e58b309ac894", size = 3349983, upload-time = "2026-03-02T15:53:25.542Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/46/0aee8f3ff20b1dcbceb46ca2d87fcc3d48b407925a383ff668218509d132/sqlalchemy-2.0.48-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:546572a1793cc35857a2ffa1fe0e58571af1779bcc1ffa7c9fb0839885ed69a9", size = 3279690, upload-time = "2026-03-02T15:50:36.277Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/a957bc91293b49181350bfd55e6dfc6e30b7f7d83dc6792d72043274a390/sqlalchemy-2.0.48-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:07edba08061bc277bfdc772dd2a1a43978f5a45994dd3ede26391b405c15221e", size = 3314738, upload-time = "2026-03-02T15:53:27.519Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/44/1d257d9f9556661e7bdc83667cc414ba210acfc110c82938cb3611eea58f/sqlalchemy-2.0.48-cp312-cp312-win32.whl", hash = "sha256:908a3fa6908716f803b86896a09a2c4dde5f5ce2bb07aacc71ffebb57986ce99", size = 2115546, upload-time = "2026-03-02T15:54:31.591Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/af/c3c7e1f3a2b383155a16454df62ae8c62a30dd238e42e68c24cebebbfae6/sqlalchemy-2.0.48-cp312-cp312-win_amd64.whl", hash = "sha256:68549c403f79a8e25984376480959975212a670405e3913830614432b5daa07a", size = 2142484, upload-time = "2026-03-02T15:54:34.072Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c6/569dc8bf3cd375abc5907e82235923e986799f301cd79a903f784b996fca/sqlalchemy-2.0.48-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e3070c03701037aa418b55d36532ecb8f8446ed0135acb71c678dbdf12f5b6e4", size = 2152599, upload-time = "2026-03-02T15:49:14.41Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ff/f4e04a4bd5a24304f38cb0d4aa2ad4c0fb34999f8b884c656535e1b2b74c/sqlalchemy-2.0.48-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2645b7d8a738763b664a12a1542c89c940daa55196e8d73e55b169cc5c99f65f", size = 3278825, upload-time = "2026-03-02T15:50:38.269Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/88/cb59509e4668d8001818d7355d9995be90c321313078c912420603a7cb95/sqlalchemy-2.0.48-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b19151e76620a412c2ac1c6f977ab1b9fa7ad43140178345136456d5265b32ed", size = 3295200, upload-time = "2026-03-02T15:53:29.366Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/1609a4442aefd750ea2f32629559394ec92e89ac1d621a7f462b70f736ff/sqlalchemy-2.0.48-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5b193a7e29fd9fa56e502920dca47dffe60f97c863494946bd698c6058a55658", size = 3226876, upload-time = "2026-03-02T15:50:39.802Z" },
+    { url = "https://files.pythonhosted.org/packages/37/c3/6ae2ab5ea2fa989fbac4e674de01224b7a9d744becaf59bb967d62e99bed/sqlalchemy-2.0.48-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:36ac4ddc3d33e852da9cb00ffb08cea62ca05c39711dc67062ca2bb1fae35fd8", size = 3265045, upload-time = "2026-03-02T15:53:31.421Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/82/ea4665d1bb98c50c19666e672f21b81356bd6077c4574e3d2bbb84541f53/sqlalchemy-2.0.48-cp313-cp313-win32.whl", hash = "sha256:389b984139278f97757ea9b08993e7b9d1142912e046ab7d82b3fbaeb0209131", size = 2113700, upload-time = "2026-03-02T15:54:35.825Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/2b/b9040bec58c58225f073f5b0c1870defe1940835549dafec680cbd58c3c3/sqlalchemy-2.0.48-cp313-cp313-win_amd64.whl", hash = "sha256:d612c976cbc2d17edfcc4c006874b764e85e990c29ce9bd411f926bbfb02b9a2", size = 2139487, upload-time = "2026-03-02T15:54:37.079Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/7b17bd50244b78a49d22cc63c969d71dc4de54567dc152a9b46f6fae40ce/sqlalchemy-2.0.48-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69f5bc24904d3bc3640961cddd2523e361257ef68585d6e364166dfbe8c78fae", size = 3558851, upload-time = "2026-03-02T15:57:48.607Z" },
+    { url = "https://files.pythonhosted.org/packages/20/0d/213668e9aca61d370f7d2a6449ea4ec699747fac67d4bda1bb3d129025be/sqlalchemy-2.0.48-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fd08b90d211c086181caed76931ecfa2bdfc83eea3cfccdb0f82abc6c4b876cb", size = 3525525, upload-time = "2026-03-02T16:04:38.058Z" },
+    { url = "https://files.pythonhosted.org/packages/85/d7/a84edf412979e7d59c69b89a5871f90a49228360594680e667cb2c46a828/sqlalchemy-2.0.48-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:1ccd42229aaac2df431562117ac7e667d702e8e44afdb6cf0e50fa3f18160f0b", size = 3466611, upload-time = "2026-03-02T15:57:50.759Z" },
+    { url = "https://files.pythonhosted.org/packages/86/55/42404ce5770f6be26a2b0607e7866c31b9a4176c819e9a7a5e0a055770be/sqlalchemy-2.0.48-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f0dcbc588cd5b725162c076eb9119342f6579c7f7f55057bb7e3c6ff27e13121", size = 3475812, upload-time = "2026-03-02T16:04:40.092Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ae/29b87775fadc43e627cf582fe3bda4d02e300f6b8f2747c764950d13784c/sqlalchemy-2.0.48-cp313-cp313t-win32.whl", hash = "sha256:9764014ef5e58aab76220c5664abb5d47d5bc858d9debf821e55cfdd0f128485", size = 2141335, upload-time = "2026-03-02T15:52:51.518Z" },
+    { url = "https://files.pythonhosted.org/packages/91/44/f39d063c90f2443e5b46ec4819abd3d8de653893aae92df42a5c4f5843de/sqlalchemy-2.0.48-cp313-cp313t-win_amd64.whl", hash = "sha256:e2f35b4cccd9ed286ad62e0a3c3ac21e06c02abc60e20aa51a3e305a30f5fa79", size = 2173095, upload-time = "2026-03-02T15:52:52.79Z" },
+    { url = "https://files.pythonhosted.org/packages/46/2c/9664130905f03db57961b8980b05cab624afd114bf2be2576628a9f22da4/sqlalchemy-2.0.48-py3-none-any.whl", hash = "sha256:a66fe406437dd65cacd96a72689a3aaaecaebbcd62d81c5ac1c0fdbeac835096", size = 1940202, upload-time = "2026-03-02T15:52:43.285Z" },
 ]
 
 [[package]]
@@ -2907,44 +2819,63 @@ wheels = [
 [[package]]
 name = "torch"
 version = "2.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version < '3.13' and sys_platform == 'darwin'",
+]
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx" },
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "sys_platform == 'darwin'" },
+    { name = "fsspec", marker = "sys_platform == 'darwin'" },
+    { name = "jinja2", marker = "sys_platform == 'darwin'" },
+    { name = "networkx", marker = "sys_platform == 'darwin'" },
+    { name = "setuptools", marker = "sys_platform == 'darwin'" },
+    { name = "sympy", marker = "sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/0c/2fd4df0d83a495bb5e54dca4474c4ec5f9c62db185421563deeb5dabf609/torch-2.8.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e2fab4153768d433f8ed9279c8133a114a034a61e77a3a104dcdf54388838705", size = 101906089, upload-time = "2025-08-06T14:53:52.631Z" },
-    { url = "https://files.pythonhosted.org/packages/99/a8/6acf48d48838fb8fe480597d98a0668c2beb02ee4755cc136de92a0a956f/torch-2.8.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:b2aca0939fb7e4d842561febbd4ffda67a8e958ff725c1c27e244e85e982173c", size = 887913624, upload-time = "2025-08-06T14:56:44.33Z" },
-    { url = "https://files.pythonhosted.org/packages/af/8a/5c87f08e3abd825c7dfecef5a0f1d9aa5df5dd0e3fd1fa2f490a8e512402/torch-2.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:2f4ac52f0130275d7517b03a33d2493bab3693c83dcfadf4f81688ea82147d2e", size = 241326087, upload-time = "2025-08-06T14:53:46.503Z" },
-    { url = "https://files.pythonhosted.org/packages/be/66/5c9a321b325aaecb92d4d1855421e3a055abd77903b7dab6575ca07796db/torch-2.8.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:619c2869db3ada2c0105487ba21b5008defcc472d23f8b80ed91ac4a380283b0", size = 73630478, upload-time = "2025-08-06T14:53:57.144Z" },
-    { url = "https://files.pythonhosted.org/packages/10/4e/469ced5a0603245d6a19a556e9053300033f9c5baccf43a3d25ba73e189e/torch-2.8.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:2b2f96814e0345f5a5aed9bf9734efa913678ed19caf6dc2cddb7930672d6128", size = 101936856, upload-time = "2025-08-06T14:54:01.526Z" },
-    { url = "https://files.pythonhosted.org/packages/16/82/3948e54c01b2109238357c6f86242e6ecbf0c63a1af46906772902f82057/torch-2.8.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:65616ca8ec6f43245e1f5f296603e33923f4c30f93d65e103d9e50c25b35150b", size = 887922844, upload-time = "2025-08-06T14:55:50.78Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/54/941ea0a860f2717d86a811adf0c2cd01b3983bdd460d0803053c4e0b8649/torch-2.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:659df54119ae03e83a800addc125856effda88b016dfc54d9f65215c3975be16", size = 241330968, upload-time = "2025-08-06T14:54:45.293Z" },
-    { url = "https://files.pythonhosted.org/packages/de/69/8b7b13bba430f5e21d77708b616f767683629fc4f8037564a177d20f90ed/torch-2.8.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:1a62a1ec4b0498930e2543535cf70b1bef8c777713de7ceb84cd79115f553767", size = 73915128, upload-time = "2025-08-06T14:54:34.769Z" },
-    { url = "https://files.pythonhosted.org/packages/15/0e/8a800e093b7f7430dbaefa80075aee9158ec22e4c4fc3c1a66e4fb96cb4f/torch-2.8.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:83c13411a26fac3d101fe8035a6b0476ae606deb8688e904e796a3534c197def", size = 102020139, upload-time = "2025-08-06T14:54:39.047Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/15/5e488ca0bc6162c86a33b58642bc577c84ded17c7b72d97e49b5833e2d73/torch-2.8.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:8f0a9d617a66509ded240add3754e462430a6c1fc5589f86c17b433dd808f97a", size = 887990692, upload-time = "2025-08-06T14:56:18.286Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/a8/6a04e4b54472fc5dba7ca2341ab219e529f3c07b6941059fbf18dccac31f/torch-2.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:a7242b86f42be98ac674b88a4988643b9bc6145437ec8f048fea23f72feb5eca", size = 241603453, upload-time = "2025-08-06T14:55:22.945Z" },
-    { url = "https://files.pythonhosted.org/packages/04/6e/650bb7f28f771af0cb791b02348db8b7f5f64f40f6829ee82aa6ce99aabe/torch-2.8.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:7b677e17f5a3e69fdef7eb3b9da72622f8d322692930297e4ccb52fefc6c8211", size = 73632395, upload-time = "2025-08-06T14:55:28.645Z" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:a47b7986bee3f61ad217d8a8ce24605809ab425baf349f97de758815edd2ef54" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:fbe2e149c5174ef90d29a5f84a554dfaf28e003cb4f61fa2c8c024c17ec7ca58" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:057efd30a6778d2ee5e2374cd63a63f63311aa6f33321e627c655df60abdd390" },
+]
+
+[[package]]
+name = "torch"
+version = "2.8.0+cpu"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
+    "(python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "(python_full_version < '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.13' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
+    "python_full_version < '3.13' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
+]
+dependencies = [
+    { name = "filelock", marker = "sys_platform != 'darwin'" },
+    { name = "fsspec", marker = "sys_platform != 'darwin'" },
+    { name = "jinja2", marker = "sys_platform != 'darwin'" },
+    { name = "networkx", marker = "sys_platform != 'darwin'" },
+    { name = "setuptools", marker = "sys_platform != 'darwin'" },
+    { name = "sympy", marker = "sys_platform != 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
+]
+wheels = [
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:0e34e276722ab7dd0dffa9e12fe2135a9b34a0e300c456ed7ad6430229404eb5" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:610f600c102386e581327d5efc18c0d6edecb9820b4140d26163354a99cd800d" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:cb9a8ba8137ab24e36bf1742cb79a1294bd374db570f09fc15a5e1318160db4e" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:2be20b2c05a0cce10430cc25f32b689259640d273232b2de357c35729132256d" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp312-cp312-win_arm64.whl", hash = "sha256:99fc421a5d234580e45957a7b02effbf3e1c884a5dd077afc85352c77bf41434" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-linux_s390x.whl", hash = "sha256:8b5882276633cf91fe3d2d7246c743b94d44a7e660b27f1308007fdb1bb89f7d" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a5064b5e23772c8d164068cc7c12e01a75faf7b948ecd95a0d4007d7487e5f25" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:8f81dedb4c6076ec325acc3b47525f9c550e5284a18eae1d9061c543f7b6e7de" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:e1ee1b2346ade3ea90306dfbec7e8ff17bc220d344109d189ae09078333b0856" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313-win_arm64.whl", hash = "sha256:64c187345509f2b1bb334feed4666e2c781ca381874bde589182f81247e61f88" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:af81283ac671f434b1b25c95ba295f270e72db1fad48831eb5e4748ff9840041" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:a9dbb6f64f63258bc811e2c0c99640a81e5af93c531ad96e95c5ec777ea46dab" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.8.0%2Bcpu-cp313-cp313t-win_amd64.whl", hash = "sha256:6d93a7165419bc4b2b907e859ccab0dea5deeab261448ae9a5ec5431f14c0e64" },
 ]
 
 [[package]]
@@ -2953,9 +2884,11 @@ version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "julius" },
-    { name = "torch" },
+    { name = "torch", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
     { name = "torch-pitch-shift" },
-    { name = "torchaudio" },
+    { name = "torchaudio", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "torchaudio", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/31/8d/2f8fd7e34c75f5ee8de4310c3bd3f22270acd44d1f809e2fe7c12fbf35f8/torch_audiomentations-0.12.0.tar.gz", hash = "sha256:b02d4c5eb86376986a53eb405cca5e34f370ea9284411237508e720c529f7888", size = 52094, upload-time = "2025-01-15T09:07:01.071Z" }
 wheels = [
@@ -2969,8 +2902,10 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
     { name = "primepy" },
-    { name = "torch" },
-    { name = "torchaudio" },
+    { name = "torch", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "torchaudio", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "torchaudio", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/79/a6/722a832bca75d5079f6731e005b3d0c2eec7c6c6863d030620952d143d57/torch_pitch_shift-1.2.5.tar.gz", hash = "sha256:6e1c7531f08d0f407a4c55e5ff8385a41355c5c5d27ab7fa08632e51defbd0ed", size = 4725, upload-time = "2024-09-25T19:10:12.922Z" }
 wheels = [
@@ -2980,23 +2915,48 @@ wheels = [
 [[package]]
 name = "torchaudio"
 version = "2.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
+    "python_full_version < '3.13' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version < '3.13' and sys_platform == 'darwin'",
+]
 dependencies = [
-    { name = "torch" },
+    { name = "torch", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/cc/c2e2a3eb6ee956f73c68541e439916f8146170ea9cc61e72adea5c995312/torchaudio-2.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ddef94bf181e6447cbb05f38beaca8f6c5bb8d2b9ddced1aa3452025b9fc70d3", size = 1856736, upload-time = "2025-08-06T14:58:36.3Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/0d/24dad878784f1edd62862f27173781669f0c71eb46368636787d1e364188/torchaudio-2.8.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:862e2e40bf09d865e5df080a84c1a39bbcef40e43140f4b1737eb3a389d3b38f", size = 1692930, upload-time = "2025-08-06T14:58:41.312Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/a6/84d80f34472503e9eb82245d7df501c59602d75d7360e717fb9b84f91c5e/torchaudio-2.8.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:93a8583f280fe83ba021aa713319381ea71362cc87b67ee38e97a43cb2254aee", size = 4014607, upload-time = "2025-08-06T14:58:47.234Z" },
-    { url = "https://files.pythonhosted.org/packages/43/ab/96ad33afa320738a7cfb4b51ba97e2f3cfb1e04ae3115d5057655103ba4f/torchaudio-2.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:4b82cacd1b8ccd543b1149d8cab257a40dfda8119023d2e3a96c66349c84bffb", size = 2499890, upload-time = "2025-08-06T14:58:55.066Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/ea/2a68259c4dbb5fe44ebfdcfa40b115010d8c677221a7ef0f5577f3c4f5f1/torchaudio-2.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f851d32e94ca05e470f0c60e25726ec1e0eb71cb2ca5a0206b7fd03272ccc3c8", size = 1857045, upload-time = "2025-08-06T14:58:51.984Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/a3/1c79a8ef29fe403b83bdfc033db852bc2a888b80c406325e5c6fb37a7f2d/torchaudio-2.8.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:09535a9b727c0793cd07c1ace99f3f353626281bcc3e30c2f2314e3ebc9d3f96", size = 1692755, upload-time = "2025-08-06T14:58:50.868Z" },
-    { url = "https://files.pythonhosted.org/packages/49/df/61941198e9ac6bcebfdd57e1836e4f3c23409308e3d8d7458f0198a6a366/torchaudio-2.8.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:d2a85b124494736241884372fe1c6dd8c15e9bc1931bd325838c5c00238c7378", size = 4013897, upload-time = "2025-08-06T14:59:01.66Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/ab/7175d35a4bbc4a465a9f1388571842f16eb6dec5069d7ea9c8c2d7b5b401/torchaudio-2.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:c1b5139c840367a7855a062a06688a416619f6fd2ca46d9b9299b49a7d133dfd", size = 2500085, upload-time = "2025-08-06T14:58:44.95Z" },
-    { url = "https://files.pythonhosted.org/packages/34/1a/69b9f8349d9d57953d5e7e445075cbf74000173fb5f5d5d9e9d59415fc63/torchaudio-2.8.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:68df9c9068984edff8065c2b6656725e6114fe89281b0cf122c7505305fc98a4", size = 1935600, upload-time = "2025-08-06T14:58:46.051Z" },
-    { url = "https://files.pythonhosted.org/packages/71/76/40fec21b65bccfdc5c8cdb9d511033ab07a7ad4b05f0a5b07f85c68279fc/torchaudio-2.8.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:1951f10ed092f2dda57634f6a3950ef21c9d9352551aa84a9fccd51bbda18095", size = 1704199, upload-time = "2025-08-06T14:58:43.594Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/53/95c3363413c2f2009f805144160b093a385f641224465fbcd717449c71fb/torchaudio-2.8.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:4f7d97494698d98854129349b12061e8c3398d33bd84c929fa9aed5fd1389f73", size = 4020596, upload-time = "2025-08-06T14:59:03.031Z" },
-    { url = "https://files.pythonhosted.org/packages/52/27/7fc2d7435af044ffbe0b9b8e98d99eac096d43f128a5cde23c04825d5dcf/torchaudio-2.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:d4a715d09ac28c920d031ee1e60ecbc91e8a5079ad8c61c0277e658436c821a6", size = 2549553, upload-time = "2025-08-06T14:59:00.019Z" },
+    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ddef94bf181e6447cbb05f38beaca8f6c5bb8d2b9ddced1aa3452025b9fc70d3" },
+    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:862e2e40bf09d865e5df080a84c1a39bbcef40e43140f4b1737eb3a389d3b38f" },
+    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f851d32e94ca05e470f0c60e25726ec1e0eb71cb2ca5a0206b7fd03272ccc3c8" },
+    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:09535a9b727c0793cd07c1ace99f3f353626281bcc3e30c2f2314e3ebc9d3f96" },
+    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:68df9c9068984edff8065c2b6656725e6114fe89281b0cf122c7505305fc98a4" },
+    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:1951f10ed092f2dda57634f6a3950ef21c9d9352551aa84a9fccd51bbda18095" },
+]
+
+[[package]]
+name = "torchaudio"
+version = "2.8.0+cpu"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
+    "(python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "(python_full_version < '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.13' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
+]
+dependencies = [
+    { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+]
+wheels = [
+    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:9377faee65a290578280ac7f4884c3586253dac2ca28c60f458ff6efe86a6b05" },
+    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:9b302192b570657c1cc787a4d487ae4bbb7f2aab1c01b1fcc46757e7f86f391e" },
+    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:e1b1f530e8b71b1d079e23db45a0e621709061710ef8540aae8280aa039554ee" },
+    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:0c2d081e24204768e636cbf05e1377c8a6964b8ed6fa3aa5092ba9af9bbc19c5" },
+    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:89c2d04fe1cb7c31eb042f7b36e1ce8e2afacf769ecd5f216527e184e4857099" },
+    { url = "https://download.pytorch.org/whl/cpu/torchaudio-2.8.0%2Bcpu-cp313-cp313t-win_amd64.whl", hash = "sha256:ab4653da31dc37f0a643f41f4da8bee647a8686bacf12d3929cac8aead186811" },
 ]
 
 [[package]]
@@ -3014,41 +2974,69 @@ wheels = [
 
 [[package]]
 name = "torchmetrics"
-version = "1.8.2"
+version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lightning-utilities" },
     { name = "numpy" },
     { name = "packaging" },
-    { name = "torch" },
+    { name = "torch", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/85/2e/48a887a59ecc4a10ce9e8b35b3e3c5cef29d902c4eac143378526e7485cb/torchmetrics-1.8.2.tar.gz", hash = "sha256:cf64a901036bf107f17a524009eea7781c9c5315d130713aeca5747a686fe7a5", size = 580679, upload-time = "2025-09-03T14:00:54.077Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/34/39b8b749333db56c0585d7a11fa62a283c087bb1dfc897d69fb8cedbefb1/torchmetrics-1.9.0.tar.gz", hash = "sha256:a488609948600df52d3db4fcdab02e62aab2a85ef34da67037dc3e65b8512faa", size = 581765, upload-time = "2026-03-09T17:41:22.443Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/21/aa0f434434c48490f91b65962b1ce863fdcce63febc166ca9fe9d706c2b6/torchmetrics-1.8.2-py3-none-any.whl", hash = "sha256:08382fd96b923e39e904c4d570f3d49e2cc71ccabd2a94e0f895d1f0dac86242", size = 983161, upload-time = "2025-09-03T14:00:51.921Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/a2/c7f6ebf546f8f644edf0f999aa98ece106986a77a7b922316bf6414ff825/torchmetrics-1.9.0-py3-none-any.whl", hash = "sha256:bfdcbff3dd1d96b3374bb2496eb39f23c4b28b8a845b6a18c313688e0d2d9ca1", size = 983384, upload-time = "2026-03-09T17:41:19.756Z" },
 ]
 
 [[package]]
 name = "torchvision"
 version = "0.23.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
+    "python_full_version < '3.13' and platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version < '3.13' and sys_platform == 'darwin'",
+]
 dependencies = [
-    { name = "numpy" },
-    { name = "pillow" },
-    { name = "torch" },
+    { name = "numpy", marker = "(platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "pillow", marker = "(platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "torch", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/1d/0ea0b34bde92a86d42620f29baa6dcbb5c2fc85990316df5cb8f7abb8ea2/torchvision-0.23.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e0e2c04a91403e8dd3af9756c6a024a1d9c0ed9c0d592a8314ded8f4fe30d440", size = 1856885, upload-time = "2025-08-06T14:58:06.503Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/00/2f6454decc0cd67158c7890364e446aad4b91797087a57a78e72e1a8f8bc/torchvision-0.23.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6dd7c4d329a0e03157803031bc856220c6155ef08c26d4f5bbac938acecf0948", size = 2396614, upload-time = "2025-08-06T14:58:03.116Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/b5/3e580dcbc16f39a324f3dd71b90edbf02a42548ad44d2b4893cc92b1194b/torchvision-0.23.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4e7d31c43bc7cbecbb1a5652ac0106b436aa66e26437585fc2c4b2cf04d6014c", size = 8627108, upload-time = "2025-08-06T14:58:12.956Z" },
-    { url = "https://files.pythonhosted.org/packages/82/c1/c2fe6d61e110a8d0de2f94276899a2324a8f1e6aee559eb6b4629ab27466/torchvision-0.23.0-cp312-cp312-win_amd64.whl", hash = "sha256:a2e45272abe7b8bf0d06c405e78521b5757be1bd0ed7e5cd78120f7fdd4cbf35", size = 1600723, upload-time = "2025-08-06T14:57:57.986Z" },
-    { url = "https://files.pythonhosted.org/packages/91/37/45a5b9407a7900f71d61b2b2f62db4b7c632debca397f205fdcacb502780/torchvision-0.23.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1c37e325e09a184b730c3ef51424f383ec5745378dc0eca244520aca29722600", size = 1856886, upload-time = "2025-08-06T14:58:05.491Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/da/a06c60fc84fc849377cf035d3b3e9a1c896d52dbad493b963c0f1cdd74d0/torchvision-0.23.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:2f7fd6c15f3697e80627b77934f77705f3bc0e98278b989b2655de01f6903e1d", size = 2353112, upload-time = "2025-08-06T14:58:26.265Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/27/5ce65ba5c9d3b7d2ccdd79892ab86a2f87ac2ca6638f04bb0280321f1a9c/torchvision-0.23.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a76fafe113b2977be3a21bf78f115438c1f88631d7a87203acb3dd6ae55889e6", size = 8627658, upload-time = "2025-08-06T14:58:15.999Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/e4/028a27b60aa578a2fa99d9d7334ff1871bb17008693ea055a2fdee96da0d/torchvision-0.23.0-cp313-cp313-win_amd64.whl", hash = "sha256:07d069cb29691ff566e3b7f11f20d91044f079e1dbdc9d72e0655899a9b06938", size = 1600749, upload-time = "2025-08-06T14:58:10.719Z" },
-    { url = "https://files.pythonhosted.org/packages/05/35/72f91ad9ac7c19a849dedf083d347dc1123f0adeb401f53974f84f1d04c8/torchvision-0.23.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:2df618e1143805a7673aaf82cb5720dd9112d4e771983156aaf2ffff692eebf9", size = 2047192, upload-time = "2025-08-06T14:58:11.813Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/9d/406cea60a9eb9882145bcd62a184ee61e823e8e1d550cdc3c3ea866a9445/torchvision-0.23.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:2a3299d2b1d5a7aed2d3b6ffb69c672ca8830671967eb1cee1497bacd82fe47b", size = 2359295, upload-time = "2025-08-06T14:58:17.469Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/f4/34662f71a70fa1e59de99772142f22257ca750de05ccb400b8d2e3809c1d/torchvision-0.23.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:76bc4c0b63d5114aa81281390f8472a12a6a35ce9906e67ea6044e5af4cab60c", size = 8800474, upload-time = "2025-08-06T14:58:22.53Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/f5/b5a2d841a8d228b5dbda6d524704408e19e7ca6b7bb0f24490e081da1fa1/torchvision-0.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:b9e2dabf0da9c8aa9ea241afb63a8f3e98489e706b22ac3f30416a1be377153b", size = 1527667, upload-time = "2025-08-06T14:58:14.446Z" },
+    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.23.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e0e2c04a91403e8dd3af9756c6a024a1d9c0ed9c0d592a8314ded8f4fe30d440" },
+    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.23.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6dd7c4d329a0e03157803031bc856220c6155ef08c26d4f5bbac938acecf0948" },
+    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.23.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1c37e325e09a184b730c3ef51424f383ec5745378dc0eca244520aca29722600" },
+    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.23.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:2f7fd6c15f3697e80627b77934f77705f3bc0e98278b989b2655de01f6903e1d" },
+    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.23.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:2df618e1143805a7673aaf82cb5720dd9112d4e771983156aaf2ffff692eebf9" },
+    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.23.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:2a3299d2b1d5a7aed2d3b6ffb69c672ca8830671967eb1cee1497bacd82fe47b" },
+]
+
+[[package]]
+name = "torchvision"
+version = "0.23.0+cpu"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
+    "(python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "(python_full_version < '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.13' and platform_python_implementation != 'CPython' and sys_platform == 'linux') or (python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')",
+]
+dependencies = [
+    { name = "numpy", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "pillow", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+]
+wheels = [
+    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.23.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:ae459d4509d3b837b978dc6c66106601f916b6d2cda75c137e3f5f48324ce1da" },
+    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.23.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:a651ccc540cf4c87eb988730c59c2220c52b57adc276f044e7efb9830fa65a1d" },
+    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.23.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:dea90a67d60a5366b0358a0b8d6bf267805278697d6fd950cf0e31139e56d1be" },
+    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.23.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:82928788025170c62e7df1120dcdc0cd175bfc31c08374613ce6d1a040bc0cda" },
+    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.23.0%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:474d77adbbbed5166db3e5636b4b4ae3399c66ef5bfa12536e254b32259c90c0" },
+    { url = "https://download.pytorch.org/whl/cpu/torchvision-0.23.0%2Bcpu-cp313-cp313t-win_amd64.whl", hash = "sha256:8d6a47e23d7896f0ef9aa7ea7179eb6324e82438aa66d19884c2020d0646b104" },
 ]
 
 [[package]]
@@ -3098,7 +3086,7 @@ name = "triton"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "setuptools" },
+    { name = "setuptools", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/66/b1eb52839f563623d185f0927eb3530ee4d5ffe9d377cdaf5346b306689e/triton-3.4.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:31c1d84a5c0ec2c0f8e8a072d7fd150cab84a9c239eaddc6706c081bfae4eb04", size = 155560068, upload-time = "2025-07-30T19:58:37.081Z" },
@@ -3163,9 +3151,12 @@ dependencies = [
     { name = "scipy" },
     { name = "setuptools" },
     { name = "swift-f0" },
-    { name = "torch" },
-    { name = "torchaudio" },
-    { name = "torchvision" },
+    { name = "torch", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "torchaudio", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "torchaudio", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "torchvision", version = "0.23.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "torchvision", version = "0.23.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
     { name = "tqdm" },
     { name = "unidecode" },
     { name = "whisperx" },
@@ -3215,9 +3206,9 @@ requires-dist = [
     { name = "scipy" },
     { name = "setuptools" },
     { name = "swift-f0" },
-    { name = "torch", specifier = "==2.8.0" },
-    { name = "torchaudio", specifier = "==2.8.0" },
-    { name = "torchvision", specifier = "==0.23.0" },
+    { name = "torch", specifier = "==2.8.0", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "torchaudio", specifier = "==2.8.0", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "torchvision", specifier = "==0.23.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "tqdm" },
     { name = "unidecode" },
     { name = "whisperx" },
@@ -3301,7 +3292,7 @@ wheels = [
 
 [[package]]
 name = "whisperx"
-version = "3.8.1"
+version = "3.8.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ctranslate2" },
@@ -3312,85 +3303,93 @@ dependencies = [
     { name = "omegaconf" },
     { name = "pandas" },
     { name = "pyannote-audio" },
-    { name = "torch" },
-    { name = "torchaudio" },
+    { name = "torch", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "torchaudio", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "torchaudio", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
     { name = "transformers" },
     { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/71/b07cc44cc58766191d69d80cf7b8078236e3af7ac2727807a7de7a35aa11/whisperx-3.8.1.tar.gz", hash = "sha256:8aa85c4c5394237950483f3c17e930ff440de1f320f3ffa4608899d6843d9a29", size = 16489226, upload-time = "2026-02-14T14:01:50.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/27/3bca053985de3c0fd17d46a972705c4d1436ad072e775b4a612e7e2a35d2/whisperx-3.8.2.tar.gz", hash = "sha256:b200b28a6d3b49a805b17965a60313c161867b95d63d85482eb0e59e06149eed", size = 16488856, upload-time = "2026-03-10T14:48:03.922Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/83/d7e8c1f26b6457530bcecab1808a10bf6a7d3f4710acff245c40bc468817/whisperx-3.8.1-py3-none-any.whl", hash = "sha256:92cc441ea8550f236f81dd5e5b54b066f085a01b25c9016c553872381dee763a", size = 16486564, upload-time = "2026-02-14T14:01:47.304Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/83/94d0bd25c0bc079d632086b4838b548ccfe00c074bd3056d72ec1cde2243/whisperx-3.8.2-py3-none-any.whl", hash = "sha256:8cc484a39f9647f186e6ee64bcde991f99828069c75cf0b2b1800d209a3c347d", size = 16485935, upload-time = "2026-03-10T14:47:59.883Z" },
 ]
 
 [[package]]
 name = "yarl"
-version = "1.22.0"
+version = "1.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
     { name = "multidict" },
     { name = "propcache" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/63/0c6ebca57330cd313f6102b16dd57ffaf3ec4c83403dcb45dbd15c6f3ea1/yarl-1.22.0.tar.gz", hash = "sha256:bebf8557577d4401ba8bd9ff33906f1376c877aa78d1fe216ad01b4d6745af71", size = 187169, upload-time = "2025-10-06T14:12:55.963Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/6e/beb1beec874a72f23815c1434518bfc4ed2175065173fb138c3705f658d4/yarl-1.23.0.tar.gz", hash = "sha256:53b1ea6ca88ebd4420379c330aea57e258408dd0df9af0992e5de2078dc9f5d5", size = 194676, upload-time = "2026-03-01T22:07:53.373Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/ff/46736024fee3429b80a165a732e38e5d5a238721e634ab41b040d49f8738/yarl-1.22.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e340382d1afa5d32b892b3ff062436d592ec3d692aeea3bef3a5cfe11bbf8c6f", size = 142000, upload-time = "2025-10-06T14:09:44.631Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/9a/b312ed670df903145598914770eb12de1bac44599549b3360acc96878df8/yarl-1.22.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f1e09112a2c31ffe8d80be1b0988fa6a18c5d5cad92a9ffbb1c04c91bfe52ad2", size = 94338, upload-time = "2025-10-06T14:09:46.372Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/f5/0601483296f09c3c65e303d60c070a5c19fcdbc72daa061e96170785bc7d/yarl-1.22.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:939fe60db294c786f6b7c2d2e121576628468f65453d86b0fe36cb52f987bd74", size = 94909, upload-time = "2025-10-06T14:09:48.648Z" },
-    { url = "https://files.pythonhosted.org/packages/60/41/9a1fe0b73dbcefce72e46cf149b0e0a67612d60bfc90fb59c2b2efdfbd86/yarl-1.22.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e1651bf8e0398574646744c1885a41198eba53dc8a9312b954073f845c90a8df", size = 372940, upload-time = "2025-10-06T14:09:50.089Z" },
-    { url = "https://files.pythonhosted.org/packages/17/7a/795cb6dfee561961c30b800f0ed616b923a2ec6258b5def2a00bf8231334/yarl-1.22.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b8a0588521a26bf92a57a1705b77b8b59044cdceccac7151bd8d229e66b8dedb", size = 345825, upload-time = "2025-10-06T14:09:52.142Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/93/a58f4d596d2be2ae7bab1a5846c4d270b894958845753b2c606d666744d3/yarl-1.22.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:42188e6a615c1a75bcaa6e150c3fe8f3e8680471a6b10150c5f7e83f47cc34d2", size = 386705, upload-time = "2025-10-06T14:09:54.128Z" },
-    { url = "https://files.pythonhosted.org/packages/61/92/682279d0e099d0e14d7fd2e176bd04f48de1484f56546a3e1313cd6c8e7c/yarl-1.22.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f6d2cb59377d99718913ad9a151030d6f83ef420a2b8f521d94609ecc106ee82", size = 396518, upload-time = "2025-10-06T14:09:55.762Z" },
-    { url = "https://files.pythonhosted.org/packages/db/0f/0d52c98b8a885aeda831224b78f3be7ec2e1aa4a62091f9f9188c3c65b56/yarl-1.22.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:50678a3b71c751d58d7908edc96d332af328839eea883bb554a43f539101277a", size = 377267, upload-time = "2025-10-06T14:09:57.958Z" },
-    { url = "https://files.pythonhosted.org/packages/22/42/d2685e35908cbeaa6532c1fc73e89e7f2efb5d8a7df3959ea8e37177c5a3/yarl-1.22.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1e8fbaa7cec507aa24ea27a01456e8dd4b6fab829059b69844bd348f2d467124", size = 365797, upload-time = "2025-10-06T14:09:59.527Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/83/cf8c7bcc6355631762f7d8bdab920ad09b82efa6b722999dfb05afa6cfac/yarl-1.22.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:433885ab5431bc3d3d4f2f9bd15bfa1614c522b0f1405d62c4f926ccd69d04fa", size = 365535, upload-time = "2025-10-06T14:10:01.139Z" },
-    { url = "https://files.pythonhosted.org/packages/25/e1/5302ff9b28f0c59cac913b91fe3f16c59a033887e57ce9ca5d41a3a94737/yarl-1.22.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b790b39c7e9a4192dc2e201a282109ed2985a1ddbd5ac08dc56d0e121400a8f7", size = 382324, upload-time = "2025-10-06T14:10:02.756Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/cd/4617eb60f032f19ae3a688dc990d8f0d89ee0ea378b61cac81ede3e52fae/yarl-1.22.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:31f0b53913220599446872d757257be5898019c85e7971599065bc55065dc99d", size = 383803, upload-time = "2025-10-06T14:10:04.552Z" },
-    { url = "https://files.pythonhosted.org/packages/59/65/afc6e62bb506a319ea67b694551dab4a7e6fb7bf604e9bd9f3e11d575fec/yarl-1.22.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a49370e8f711daec68d09b821a34e1167792ee2d24d405cbc2387be4f158b520", size = 374220, upload-time = "2025-10-06T14:10:06.489Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/3d/68bf18d50dc674b942daec86a9ba922d3113d8399b0e52b9897530442da2/yarl-1.22.0-cp312-cp312-win32.whl", hash = "sha256:70dfd4f241c04bd9239d53b17f11e6ab672b9f1420364af63e8531198e3f5fe8", size = 81589, upload-time = "2025-10-06T14:10:09.254Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/9a/6ad1a9b37c2f72874f93e691b2e7ecb6137fb2b899983125db4204e47575/yarl-1.22.0-cp312-cp312-win_amd64.whl", hash = "sha256:8884d8b332a5e9b88e23f60bb166890009429391864c685e17bd73a9eda9105c", size = 87213, upload-time = "2025-10-06T14:10:11.369Z" },
-    { url = "https://files.pythonhosted.org/packages/44/c5/c21b562d1680a77634d748e30c653c3ca918beb35555cff24986fff54598/yarl-1.22.0-cp312-cp312-win_arm64.whl", hash = "sha256:ea70f61a47f3cc93bdf8b2f368ed359ef02a01ca6393916bc8ff877427181e74", size = 81330, upload-time = "2025-10-06T14:10:13.112Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/f3/d67de7260456ee105dc1d162d43a019ecad6b91e2f51809d6cddaa56690e/yarl-1.22.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8dee9c25c74997f6a750cd317b8ca63545169c098faee42c84aa5e506c819b53", size = 139980, upload-time = "2025-10-06T14:10:14.601Z" },
-    { url = "https://files.pythonhosted.org/packages/01/88/04d98af0b47e0ef42597b9b28863b9060bb515524da0a65d5f4db160b2d5/yarl-1.22.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:01e73b85a5434f89fc4fe27dcda2aff08ddf35e4d47bbbea3bdcd25321af538a", size = 93424, upload-time = "2025-10-06T14:10:16.115Z" },
-    { url = "https://files.pythonhosted.org/packages/18/91/3274b215fd8442a03975ce6bee5fe6aa57a8326b29b9d3d56234a1dca244/yarl-1.22.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:22965c2af250d20c873cdbee8ff958fb809940aeb2e74ba5f20aaf6b7ac8c70c", size = 93821, upload-time = "2025-10-06T14:10:17.993Z" },
-    { url = "https://files.pythonhosted.org/packages/61/3a/caf4e25036db0f2da4ca22a353dfeb3c9d3c95d2761ebe9b14df8fc16eb0/yarl-1.22.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4f15793aa49793ec8d1c708ab7f9eded1aa72edc5174cae703651555ed1b601", size = 373243, upload-time = "2025-10-06T14:10:19.44Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/9e/51a77ac7516e8e7803b06e01f74e78649c24ee1021eca3d6a739cb6ea49c/yarl-1.22.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e5542339dcf2747135c5c85f68680353d5cb9ffd741c0f2e8d832d054d41f35a", size = 342361, upload-time = "2025-10-06T14:10:21.124Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/f8/33b92454789dde8407f156c00303e9a891f1f51a0330b0fad7c909f87692/yarl-1.22.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5c401e05ad47a75869c3ab3e35137f8468b846770587e70d71e11de797d113df", size = 387036, upload-time = "2025-10-06T14:10:22.902Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/9a/c5db84ea024f76838220280f732970aa4ee154015d7f5c1bfb60a267af6f/yarl-1.22.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:243dda95d901c733f5b59214d28b0120893d91777cb8aa043e6ef059d3cddfe2", size = 397671, upload-time = "2025-10-06T14:10:24.523Z" },
-    { url = "https://files.pythonhosted.org/packages/11/c9/cd8538dc2e7727095e0c1d867bad1e40c98f37763e6d995c1939f5fdc7b1/yarl-1.22.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bec03d0d388060058f5d291a813f21c011041938a441c593374da6077fe21b1b", size = 377059, upload-time = "2025-10-06T14:10:26.406Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/b9/ab437b261702ced75122ed78a876a6dec0a1b0f5e17a4ac7a9a2482d8abe/yarl-1.22.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b0748275abb8c1e1e09301ee3cf90c8a99678a4e92e4373705f2a2570d581273", size = 365356, upload-time = "2025-10-06T14:10:28.461Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/9d/8e1ae6d1d008a9567877b08f0ce4077a29974c04c062dabdb923ed98e6fe/yarl-1.22.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:47fdb18187e2a4e18fda2c25c05d8251a9e4a521edaed757fef033e7d8498d9a", size = 361331, upload-time = "2025-10-06T14:10:30.541Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/5a/09b7be3905962f145b73beb468cdd53db8aa171cf18c80400a54c5b82846/yarl-1.22.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:c7044802eec4524fde550afc28edda0dd5784c4c45f0be151a2d3ba017daca7d", size = 382590, upload-time = "2025-10-06T14:10:33.352Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/7f/59ec509abf90eda5048b0bc3e2d7b5099dffdb3e6b127019895ab9d5ef44/yarl-1.22.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:139718f35149ff544caba20fce6e8a2f71f1e39b92c700d8438a0b1d2a631a02", size = 385316, upload-time = "2025-10-06T14:10:35.034Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/84/891158426bc8036bfdfd862fabd0e0fa25df4176ec793e447f4b85cf1be4/yarl-1.22.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e1b51bebd221006d3d2f95fbe124b22b247136647ae5dcc8c7acafba66e5ee67", size = 374431, upload-time = "2025-10-06T14:10:37.76Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/49/03da1580665baa8bef5e8ed34c6df2c2aca0a2f28bf397ed238cc1bbc6f2/yarl-1.22.0-cp313-cp313-win32.whl", hash = "sha256:d3e32536234a95f513bd374e93d717cf6b2231a791758de6c509e3653f234c95", size = 81555, upload-time = "2025-10-06T14:10:39.649Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/ee/450914ae11b419eadd067c6183ae08381cfdfcb9798b90b2b713bbebddda/yarl-1.22.0-cp313-cp313-win_amd64.whl", hash = "sha256:47743b82b76d89a1d20b83e60d5c20314cbd5ba2befc9cda8f28300c4a08ed4d", size = 86965, upload-time = "2025-10-06T14:10:41.313Z" },
-    { url = "https://files.pythonhosted.org/packages/98/4d/264a01eae03b6cf629ad69bae94e3b0e5344741e929073678e84bf7a3e3b/yarl-1.22.0-cp313-cp313-win_arm64.whl", hash = "sha256:5d0fcda9608875f7d052eff120c7a5da474a6796fe4d83e152e0e4d42f6d1a9b", size = 81205, upload-time = "2025-10-06T14:10:43.167Z" },
-    { url = "https://files.pythonhosted.org/packages/88/fc/6908f062a2f77b5f9f6d69cecb1747260831ff206adcbc5b510aff88df91/yarl-1.22.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:719ae08b6972befcba4310e49edb1161a88cdd331e3a694b84466bd938a6ab10", size = 146209, upload-time = "2025-10-06T14:10:44.643Z" },
-    { url = "https://files.pythonhosted.org/packages/65/47/76594ae8eab26210b4867be6f49129861ad33da1f1ebdf7051e98492bf62/yarl-1.22.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:47d8a5c446df1c4db9d21b49619ffdba90e77c89ec6e283f453856c74b50b9e3", size = 95966, upload-time = "2025-10-06T14:10:46.554Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/ce/05e9828a49271ba6b5b038b15b3934e996980dd78abdfeb52a04cfb9467e/yarl-1.22.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cfebc0ac8333520d2d0423cbbe43ae43c8838862ddb898f5ca68565e395516e9", size = 97312, upload-time = "2025-10-06T14:10:48.007Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/c5/7dffad5e4f2265b29c9d7ec869c369e4223166e4f9206fc2243ee9eea727/yarl-1.22.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4398557cbf484207df000309235979c79c4356518fd5c99158c7d38203c4da4f", size = 361967, upload-time = "2025-10-06T14:10:49.997Z" },
-    { url = "https://files.pythonhosted.org/packages/50/b2/375b933c93a54bff7fc041e1a6ad2c0f6f733ffb0c6e642ce56ee3b39970/yarl-1.22.0-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2ca6fd72a8cd803be290d42f2dec5cdcd5299eeb93c2d929bf060ad9efaf5de0", size = 323949, upload-time = "2025-10-06T14:10:52.004Z" },
-    { url = "https://files.pythonhosted.org/packages/66/50/bfc2a29a1d78644c5a7220ce2f304f38248dc94124a326794e677634b6cf/yarl-1.22.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ca1f59c4e1ab6e72f0a23c13fca5430f889634166be85dbf1013683e49e3278e", size = 361818, upload-time = "2025-10-06T14:10:54.078Z" },
-    { url = "https://files.pythonhosted.org/packages/46/96/f3941a46af7d5d0f0498f86d71275696800ddcdd20426298e572b19b91ff/yarl-1.22.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c5010a52015e7c70f86eb967db0f37f3c8bd503a695a49f8d45700144667708", size = 372626, upload-time = "2025-10-06T14:10:55.767Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/42/8b27c83bb875cd89448e42cd627e0fb971fa1675c9ec546393d18826cb50/yarl-1.22.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d7672ecf7557476642c88497c2f8d8542f8e36596e928e9bcba0e42e1e7d71f", size = 341129, upload-time = "2025-10-06T14:10:57.985Z" },
-    { url = "https://files.pythonhosted.org/packages/49/36/99ca3122201b382a3cf7cc937b95235b0ac944f7e9f2d5331d50821ed352/yarl-1.22.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:3b7c88eeef021579d600e50363e0b6ee4f7f6f728cd3486b9d0f3ee7b946398d", size = 346776, upload-time = "2025-10-06T14:10:59.633Z" },
-    { url = "https://files.pythonhosted.org/packages/85/b4/47328bf996acd01a4c16ef9dcd2f59c969f495073616586f78cd5f2efb99/yarl-1.22.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:f4afb5c34f2c6fecdcc182dfcfc6af6cccf1aa923eed4d6a12e9d96904e1a0d8", size = 334879, upload-time = "2025-10-06T14:11:01.454Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/ad/b77d7b3f14a4283bffb8e92c6026496f6de49751c2f97d4352242bba3990/yarl-1.22.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:59c189e3e99a59cf8d83cbb31d4db02d66cda5a1a4374e8a012b51255341abf5", size = 350996, upload-time = "2025-10-06T14:11:03.452Z" },
-    { url = "https://files.pythonhosted.org/packages/81/c8/06e1d69295792ba54d556f06686cbd6a7ce39c22307100e3fb4a2c0b0a1d/yarl-1.22.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:5a3bf7f62a289fa90f1990422dc8dff5a458469ea71d1624585ec3a4c8d6960f", size = 356047, upload-time = "2025-10-06T14:11:05.115Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/b8/4c0e9e9f597074b208d18cef227d83aac36184bfbc6eab204ea55783dbc5/yarl-1.22.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:de6b9a04c606978fdfe72666fa216ffcf2d1a9f6a381058d4378f8d7b1e5de62", size = 342947, upload-time = "2025-10-06T14:11:08.137Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/e5/11f140a58bf4c6ad7aca69a892bff0ee638c31bea4206748fc0df4ebcb3a/yarl-1.22.0-cp313-cp313t-win32.whl", hash = "sha256:1834bb90991cc2999f10f97f5f01317f99b143284766d197e43cd5b45eb18d03", size = 86943, upload-time = "2025-10-06T14:11:10.284Z" },
-    { url = "https://files.pythonhosted.org/packages/31/74/8b74bae38ed7fe6793d0c15a0c8207bbb819cf287788459e5ed230996cdd/yarl-1.22.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ff86011bd159a9d2dfc89c34cfd8aff12875980e3bd6a39ff097887520e60249", size = 93715, upload-time = "2025-10-06T14:11:11.739Z" },
-    { url = "https://files.pythonhosted.org/packages/69/66/991858aa4b5892d57aef7ee1ba6b4d01ec3b7eb3060795d34090a3ca3278/yarl-1.22.0-cp313-cp313t-win_arm64.whl", hash = "sha256:7861058d0582b847bc4e3a4a4c46828a410bca738673f35a29ba3ca5db0b473b", size = 83857, upload-time = "2025-10-06T14:11:13.586Z" },
-    { url = "https://files.pythonhosted.org/packages/73/ae/b48f95715333080afb75a4504487cbe142cae1268afc482d06692d605ae6/yarl-1.22.0-py3-none-any.whl", hash = "sha256:1380560bdba02b6b6c90de54133c81c9f2a453dee9912fe58c1dcced1edb7cff", size = 46814, upload-time = "2025-10-06T14:12:53.872Z" },
+    { url = "https://files.pythonhosted.org/packages/88/8a/94615bc31022f711add374097ad4144d569e95ff3c38d39215d07ac153a0/yarl-1.23.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1932b6b8bba8d0160a9d1078aae5838a66039e8832d41d2992daa9a3a08f7860", size = 124737, upload-time = "2026-03-01T22:05:12.897Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/6f/c6554045d59d64052698add01226bc867b52fe4a12373415d7991fdca95d/yarl-1.23.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:411225bae281f114067578891bc75534cfb3d92a3b4dfef7a6ca78ba354e6069", size = 87029, upload-time = "2026-03-01T22:05:14.376Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/725ecc166d53438bc88f76822ed4b1e3b10756e790bafd7b523fe97c322d/yarl-1.23.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:13a563739ae600a631c36ce096615fe307f131344588b0bc0daec108cdb47b25", size = 86310, upload-time = "2026-03-01T22:05:15.71Z" },
+    { url = "https://files.pythonhosted.org/packages/99/30/58260ed98e6ff7f90ba84442c1ddd758c9170d70327394a6227b310cd60f/yarl-1.23.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cbf44c5cb4a7633d078788e1b56387e3d3cf2b8139a3be38040b22d6c3221c8", size = 97587, upload-time = "2026-03-01T22:05:17.384Z" },
+    { url = "https://files.pythonhosted.org/packages/76/0a/8b08aac08b50682e65759f7f8dde98ae8168f72487e7357a5d684c581ef9/yarl-1.23.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:53ad387048f6f09a8969631e4de3f1bf70c50e93545d64af4f751b2498755072", size = 92528, upload-time = "2026-03-01T22:05:18.804Z" },
+    { url = "https://files.pythonhosted.org/packages/52/07/0b7179101fe5f8385ec6c6bb5d0cb9f76bd9fb4a769591ab6fb5cdbfc69a/yarl-1.23.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4a59ba56f340334766f3a4442e0efd0af895fae9e2b204741ef885c446b3a1a8", size = 105339, upload-time = "2026-03-01T22:05:20.235Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/8a/36d82869ab5ec829ca8574dfcb92b51286fcfb1e9c7a73659616362dc880/yarl-1.23.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:803a3c3ce4acc62eaf01eaca1208dcf0783025ef27572c3336502b9c232005e7", size = 105061, upload-time = "2026-03-01T22:05:22.268Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3e/868e5c3364b6cee19ff3e1a122194fa4ce51def02c61023970442162859e/yarl-1.23.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a3d2bff8f37f8d0f96c7ec554d16945050d54462d6e95414babaa18bfafc7f51", size = 100132, upload-time = "2026-03-01T22:05:23.638Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/26/9c89acf82f08a52cb52d6d39454f8d18af15f9d386a23795389d1d423823/yarl-1.23.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c75eb09e8d55bceb4367e83496ff8ef2bc7ea6960efb38e978e8073ea59ecb67", size = 99289, upload-time = "2026-03-01T22:05:25.749Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/54/5b0db00d2cb056922356104468019c0a132e89c8d3ab67d8ede9f4483d2a/yarl-1.23.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:877b0738624280e34c55680d6054a307aa94f7d52fa0e3034a9cc6e790871da7", size = 96950, upload-time = "2026-03-01T22:05:27.318Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/40/10fa93811fd439341fad7e0718a86aca0de9548023bbb403668d6555acab/yarl-1.23.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b5405bb8f0e783a988172993cfc627e4d9d00432d6bbac65a923041edacf997d", size = 93960, upload-time = "2026-03-01T22:05:28.738Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d2/8ae2e6cd77d0805f4526e30ec43b6f9a3dfc542d401ac4990d178e4bf0cf/yarl-1.23.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1c3a3598a832590c5a3ce56ab5576361b5688c12cb1d39429cf5dba30b510760", size = 104703, upload-time = "2026-03-01T22:05:30.438Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/0c/b3ceacf82c3fe21183ce35fa2acf5320af003d52bc1fcf5915077681142e/yarl-1.23.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:8419ebd326430d1cbb7efb5292330a2cf39114e82df5cc3d83c9a0d5ebeaf2f2", size = 98325, upload-time = "2026-03-01T22:05:31.835Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/e0/12900edd28bdab91a69bd2554b85ad7b151f64e8b521fe16f9ad2f56477a/yarl-1.23.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:be61f6fff406ca40e3b1d84716fde398fc08bc63dd96d15f3a14230a0973ed86", size = 105067, upload-time = "2026-03-01T22:05:33.358Z" },
+    { url = "https://files.pythonhosted.org/packages/15/61/74bb1182cf79c9bbe4eb6b1f14a57a22d7a0be5e9cedf8e2d5c2086474c3/yarl-1.23.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3ceb13c5c858d01321b5d9bb65e4cf37a92169ea470b70fec6f236b2c9dd7e34", size = 100285, upload-time = "2026-03-01T22:05:35.4Z" },
+    { url = "https://files.pythonhosted.org/packages/69/7f/cd5ef733f2550de6241bd8bd8c3febc78158b9d75f197d9c7baa113436af/yarl-1.23.0-cp312-cp312-win32.whl", hash = "sha256:fffc45637bcd6538de8b85f51e3df3223e4ad89bccbfca0481c08c7fc8b7ed7d", size = 82359, upload-time = "2026-03-01T22:05:36.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/be/25216a49daeeb7af2bec0db22d5e7df08ed1d7c9f65d78b14f3b74fd72fc/yarl-1.23.0-cp312-cp312-win_amd64.whl", hash = "sha256:f69f57305656a4852f2a7203efc661d8c042e6cc67f7acd97d8667fb448a426e", size = 87674, upload-time = "2026-03-01T22:05:38.171Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/35/aeab955d6c425b227d5b7247eafb24f2653fedc32f95373a001af5dfeb9e/yarl-1.23.0-cp312-cp312-win_arm64.whl", hash = "sha256:6e87a6e8735b44816e7db0b2fbc9686932df473c826b0d9743148432e10bb9b9", size = 81879, upload-time = "2026-03-01T22:05:40.006Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/4b/a0a6e5d0ee8a2f3a373ddef8a4097d74ac901ac363eea1440464ccbe0898/yarl-1.23.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:16c6994ac35c3e74fb0ae93323bf8b9c2a9088d55946109489667c510a7d010e", size = 123796, upload-time = "2026-03-01T22:05:41.412Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b6/8925d68af039b835ae876db5838e82e76ec87b9782ecc97e192b809c4831/yarl-1.23.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4a42e651629dafb64fd5b0286a3580613702b5809ad3f24934ea87595804f2c5", size = 86547, upload-time = "2026-03-01T22:05:42.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/50/06d511cc4b8e0360d3c94af051a768e84b755c5eb031b12adaaab6dec6e5/yarl-1.23.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7c6b9461a2a8b47c65eef63bb1c76a4f1c119618ffa99ea79bc5bb1e46c5821b", size = 85854, upload-time = "2026-03-01T22:05:44.85Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f4/4e30b250927ffdab4db70da08b9b8d2194d7c7b400167b8fbeca1e4701ca/yarl-1.23.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2569b67d616eab450d262ca7cb9f9e19d2f718c70a8b88712859359d0ab17035", size = 98351, upload-time = "2026-03-01T22:05:46.836Z" },
+    { url = "https://files.pythonhosted.org/packages/86/fc/4118c5671ea948208bdb1492d8b76bdf1453d3e73df051f939f563e7dcc5/yarl-1.23.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e9d9a4d06d3481eab79803beb4d9bd6f6a8e781ec078ac70d7ef2dcc29d1bea5", size = 92711, upload-time = "2026-03-01T22:05:48.316Z" },
+    { url = "https://files.pythonhosted.org/packages/56/11/1ed91d42bd9e73c13dc9e7eb0dd92298d75e7ac4dd7f046ad0c472e231cd/yarl-1.23.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f514f6474e04179d3d33175ed3f3e31434d3130d42ec153540d5b157deefd735", size = 106014, upload-time = "2026-03-01T22:05:50.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/c9/74e44e056a23fbc33aca71779ef450ca648a5bc472bdad7a82339918f818/yarl-1.23.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fda207c815b253e34f7e1909840fd14299567b1c0eb4908f8c2ce01a41265401", size = 105557, upload-time = "2026-03-01T22:05:51.416Z" },
+    { url = "https://files.pythonhosted.org/packages/66/fe/b1e10b08d287f518994f1e2ff9b6d26f0adeecd8dd7d533b01bab29a3eda/yarl-1.23.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34b6cf500e61c90f305094911f9acc9c86da1a05a7a3f5be9f68817043f486e4", size = 101559, upload-time = "2026-03-01T22:05:52.872Z" },
+    { url = "https://files.pythonhosted.org/packages/72/59/c5b8d94b14e3d3c2a9c20cb100119fd534ab5a14b93673ab4cc4a4141ea5/yarl-1.23.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d7504f2b476d21653e4d143f44a175f7f751cd41233525312696c76aa3dbb23f", size = 100502, upload-time = "2026-03-01T22:05:54.954Z" },
+    { url = "https://files.pythonhosted.org/packages/77/4f/96976cb54cbfc5c9fd73ed4c51804f92f209481d1fb190981c0f8a07a1d7/yarl-1.23.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:578110dd426f0d209d1509244e6d4a3f1a3e9077655d98c5f22583d63252a08a", size = 98027, upload-time = "2026-03-01T22:05:56.409Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6e/904c4f476471afdbad6b7e5b70362fb5810e35cd7466529a97322b6f5556/yarl-1.23.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:609d3614d78d74ebe35f54953c5bbd2ac647a7ddb9c30a5d877580f5e86b22f2", size = 95369, upload-time = "2026-03-01T22:05:58.141Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/40/acfcdb3b5f9d68ef499e39e04d25e141fe90661f9d54114556cf83be8353/yarl-1.23.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4966242ec68afc74c122f8459abd597afd7d8a60dc93d695c1334c5fd25f762f", size = 105565, upload-time = "2026-03-01T22:06:00.286Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/c6/31e28f3a6ba2869c43d124f37ea5260cac9c9281df803c354b31f4dd1f3c/yarl-1.23.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e0fd068364a6759bc794459f0a735ab151d11304346332489c7972bacbe9e72b", size = 99813, upload-time = "2026-03-01T22:06:01.712Z" },
+    { url = "https://files.pythonhosted.org/packages/08/1f/6f65f59e72d54aa467119b63fc0b0b1762eff0232db1f4720cd89e2f4a17/yarl-1.23.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:39004f0ad156da43e86aa71f44e033de68a44e5a31fc53507b36dd253970054a", size = 105632, upload-time = "2026-03-01T22:06:03.188Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c4/18b178a69935f9e7a338127d5b77d868fdc0f0e49becd286d51b3a18c61d/yarl-1.23.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e5723c01a56c5028c807c701aa66722916d2747ad737a046853f6c46f4875543", size = 101895, upload-time = "2026-03-01T22:06:04.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/54/f5b870b5505663911dba950a8e4776a0dbd51c9c54c0ae88e823e4b874a0/yarl-1.23.0-cp313-cp313-win32.whl", hash = "sha256:1b6b572edd95b4fa8df75de10b04bc81acc87c1c7d16bcdd2035b09d30acc957", size = 82356, upload-time = "2026-03-01T22:06:06.04Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/84/266e8da36879c6edcd37b02b547e2d9ecdfea776be49598e75696e3316e1/yarl-1.23.0-cp313-cp313-win_amd64.whl", hash = "sha256:baaf55442359053c7d62f6f8413a62adba3205119bcb6f49594894d8be47e5e3", size = 87515, upload-time = "2026-03-01T22:06:08.107Z" },
+    { url = "https://files.pythonhosted.org/packages/00/fd/7e1c66efad35e1649114fa13f17485f62881ad58edeeb7f49f8c5e748bf9/yarl-1.23.0-cp313-cp313-win_arm64.whl", hash = "sha256:fb4948814a2a98e3912505f09c9e7493b1506226afb1f881825368d6fb776ee3", size = 81785, upload-time = "2026-03-01T22:06:10.181Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/fc/119dd07004f17ea43bb91e3ece6587759edd7519d6b086d16bfbd3319982/yarl-1.23.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:aecfed0b41aa72b7881712c65cf764e39ce2ec352324f5e0837c7048d9e6daaa", size = 130719, upload-time = "2026-03-01T22:06:11.708Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/0d/9f2348502fbb3af409e8f47730282cd6bc80dec6630c1e06374d882d6eb2/yarl-1.23.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:a41bcf68efd19073376eb8cf948b8d9be0af26256403e512bb18f3966f1f9120", size = 89690, upload-time = "2026-03-01T22:06:13.429Z" },
+    { url = "https://files.pythonhosted.org/packages/50/93/e88f3c80971b42cfc83f50a51b9d165a1dbf154b97005f2994a79f212a07/yarl-1.23.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cde9a2ecd91668bcb7f077c4966d8ceddb60af01b52e6e3e2680e4cf00ad1a59", size = 89851, upload-time = "2026-03-01T22:06:15.53Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/07/61c9dd8ba8f86473263b4036f70fb594c09e99c0d9737a799dfd8bc85651/yarl-1.23.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5023346c4ee7992febc0068e7593de5fa2bf611848c08404b35ebbb76b1b0512", size = 95874, upload-time = "2026-03-01T22:06:17.553Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e9/f9ff8ceefba599eac6abddcfb0b3bee9b9e636e96dbf54342a8577252379/yarl-1.23.0-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d1009abedb49ae95b136a8904a3f71b342f849ffeced2d3747bf29caeda218c4", size = 88710, upload-time = "2026-03-01T22:06:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/78/0231bfcc5d4c8eec220bc2f9ef82cb4566192ea867a7c5b4148f44f6cbcd/yarl-1.23.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a8d00f29b42f534cc8aa3931cfe773b13b23e561e10d2b26f27a8d309b0e82a1", size = 101033, upload-time = "2026-03-01T22:06:21.203Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/9b/30ea5239a61786f18fd25797151a17fbb3be176977187a48d541b5447dd4/yarl-1.23.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:95451e6ce06c3e104556d73b559f5da6c34a069b6b62946d3ad66afcd51642ea", size = 100817, upload-time = "2026-03-01T22:06:22.738Z" },
+    { url = "https://files.pythonhosted.org/packages/62/e2/a4980481071791bc83bce2b7a1a1f7adcabfa366007518b4b845e92eeee3/yarl-1.23.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:531ef597132086b6cf96faa7c6c1dcd0361dd5f1694e5cc30375907b9b7d3ea9", size = 97482, upload-time = "2026-03-01T22:06:24.21Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1e/304a00cf5f6100414c4b5a01fc7ff9ee724b62158a08df2f8170dfc72a2d/yarl-1.23.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:88f9fb0116fbfcefcab70f85cf4b74a2b6ce5d199c41345296f49d974ddb4123", size = 95949, upload-time = "2026-03-01T22:06:25.697Z" },
+    { url = "https://files.pythonhosted.org/packages/68/03/093f4055ed4cae649ac53bca3d180bd37102e9e11d048588e9ab0c0108d0/yarl-1.23.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e7b0460976dc75cb87ad9cc1f9899a4b97751e7d4e77ab840fc9b6d377b8fd24", size = 95839, upload-time = "2026-03-01T22:06:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/28/4c75ebb108f322aa8f917ae10a8ffa4f07cae10a8a627b64e578617df6a0/yarl-1.23.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:115136c4a426f9da976187d238e84139ff6b51a20839aa6e3720cd1026d768de", size = 90696, upload-time = "2026-03-01T22:06:29.048Z" },
+    { url = "https://files.pythonhosted.org/packages/23/9c/42c2e2dd91c1a570402f51bdf066bfdb1241c2240ba001967bad778e77b7/yarl-1.23.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:ead11956716a940c1abc816b7df3fa2b84d06eaed8832ca32f5c5e058c65506b", size = 100865, upload-time = "2026-03-01T22:06:30.525Z" },
+    { url = "https://files.pythonhosted.org/packages/74/05/1bcd60a8a0a914d462c305137246b6f9d167628d73568505fce3f1cb2e65/yarl-1.23.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:fe8f8f5e70e6dbdfca9882cd9deaac058729bcf323cf7a58660901e55c9c94f6", size = 96234, upload-time = "2026-03-01T22:06:32.692Z" },
+    { url = "https://files.pythonhosted.org/packages/90/b2/f52381aac396d6778ce516b7bc149c79e65bfc068b5de2857ab69eeea3b7/yarl-1.23.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:a0e317df055958a0c1e79e5d2aa5a5eaa4a6d05a20d4b0c9c3f48918139c9fc6", size = 100295, upload-time = "2026-03-01T22:06:34.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/638bae5bbf1113a659b2435d8895474598afe38b4a837103764f603aba56/yarl-1.23.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6f0fd84de0c957b2d280143522c4f91a73aada1923caee763e24a2b3fda9f8a5", size = 97784, upload-time = "2026-03-01T22:06:35.864Z" },
+    { url = "https://files.pythonhosted.org/packages/80/25/a3892b46182c586c202629fc2159aa13975d3741d52ebd7347fd501d48d5/yarl-1.23.0-cp313-cp313t-win32.whl", hash = "sha256:93a784271881035ab4406a172edb0faecb6e7d00f4b53dc2f55919d6c9688595", size = 88313, upload-time = "2026-03-01T22:06:37.39Z" },
+    { url = "https://files.pythonhosted.org/packages/43/68/8c5b36aa5178900b37387937bc2c2fe0e9505537f713495472dcf6f6fccc/yarl-1.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:dd00607bffbf30250fe108065f07453ec124dbf223420f57f5e749b04295e090", size = 94932, upload-time = "2026-03-01T22:06:39.579Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/cc/d79ba8292f51f81f4dc533a8ccfb9fc6992cabf0998ed3245de7589dc07c/yarl-1.23.0-cp313-cp313t-win_arm64.whl", hash = "sha256:ac09d42f48f80c9ee1635b2fcaa819496a44502737660d3c0f2ade7526d29144", size = 84786, upload-time = "2026-03-01T22:06:41.988Z" },
+    { url = "https://files.pythonhosted.org/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
 ]
 
 [[package]]
 name = "yt-dlp"
-version = "2026.2.21"
+version = "2026.3.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/d9/55ffff25204733e94a507552ad984d5a8a8e4f9d1f0d91763e6b1a41c79b/yt_dlp-2026.2.21.tar.gz", hash = "sha256:4407dfc1a71fec0dee5ef916a8d4b66057812939b509ae45451fa8fb4376b539", size = 3116630, upload-time = "2026-02-21T20:40:53.522Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/6f/7427d23609353e5ef3470ff43ef551b8bd7b166dd4fef48957f0d0e040fe/yt_dlp-2026.3.3.tar.gz", hash = "sha256:3db7969e3a8964dc786bdebcffa2653f31123bf2a630f04a17bdafb7bbd39952", size = 3118658, upload-time = "2026-03-03T16:54:53.909Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/40/664c99ee36d80d84ce7a96cd98aebcb3d16c19e6c3ad3461d2cf5424040e/yt_dlp-2026.2.21-py3-none-any.whl", hash = "sha256:0d8408f5b6d20487f5caeb946dfd04f9bcd2f1a3a125b744a0a982b590e449f7", size = 3313392, upload-time = "2026-02-21T20:40:51.514Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/a4/8b5cd28ab87aef48ef15e74241befec3445496327db028f34147a9e0f14f/yt_dlp-2026.3.3-py3-none-any.whl", hash = "sha256:166c6e68c49ba526474bd400e0129f58aa522c2896204aa73be669c3d2f15e63", size = 3315599, upload-time = "2026-03-03T16:54:51.899Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Removes the dead `\ufffd` check in `_read_txt_lines()` (strict decode raises `UnicodeDecodeError`, never inserts U+FFFD)
- Fixes docstring to accurately describe strict decoding behavior
- Addresses CodeRabbit finding from PR #26 review

## Context
The `_read_txt_lines()` function uses strict decoding (no `errors` parameter), so invalid bytes raise `UnicodeDecodeError` rather than inserting U+FFFD. The `\ufffd` check was:
1. **Dead code** for invalid input (exception raised before U+FFFD could appear)
2. **Potentially harmful** for files legitimately containing U+FFFD characters (would incorrectly fall through to CP1252/Latin-1)

## Test plan
- [x] All 142 tests pass (3 skipped)
- [x] No behavioral change for normal files (strict decode + exception fallback chain unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added `--bpm` option to manually override BPM detection
  * Added `--octave` option to shift all notes by specified octaves
  * Enhanced denoising with configurable noise reduction, noise floor, and adaptive tracking
  * Added tools for comparing and fixing UltraStar file compatibility

* **Bug Fixes**
  * Improved BPM detection with automatic tempo correction
  * Enhanced MIDI note accuracy using confidence-weighted selection
  * Fixed octave-related issues in MIDI generation with outlier correction

* **Documentation**
  * Updated README with new CLI options and usage examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->